### PR TITLE
Use finalizer to cleanup DB on CR delete

### DIFF
--- a/pkg/database.go
+++ b/pkg/database.go
@@ -69,3 +69,48 @@ func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName s
 
 	return job
 }
+
+func DeleteDbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName string, databaseSecret string, containerImage string) *batchv1.Job {
+
+	opts := dbCreateOptions{database.Spec.Name, databaseHostName, "root"}
+	labels := map[string]string{
+		"owner": "mariadb-operator", "cr": database.Spec.Name, "app": "mariadbschema",
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      database.Spec.Name + "-database-delete",
+			Namespace: database.Namespace,
+			Labels:    labels,
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy:      "OnFailure",
+					ServiceAccountName: "mariadb",
+					Containers: []corev1.Container{
+						{
+							Name:    "mariadb-database-create",
+							Image:   containerImage,
+							Command: []string{"/bin/sh", "-c", util.ExecuteTemplateFile("delete_database.sh", &opts)},
+							Env: []corev1.EnvVar{
+								{
+									Name: "MYSQL_PWD",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: databaseSecret,
+											},
+											Key: "DbRootPassword",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return job
+}

--- a/templates/delete_database.sh
+++ b/templates/delete_database.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "DROP DATABASE IF EXISTS {{.DatabaseName}}; DROP USER IF EXISTS '{{.DatabaseName}}'@'localhost'; DROP USER IF EXISTS '{{.DatabaseName}}'@'%';"


### PR DESCRIPTION
Introduces a finalizer to run a DB delete job on CR delete to be
able to cleanup also DB from other operators.