### PR TITLE
Allow underscore in db names like nova_api, nova_cell0

### DIFF
--- a/pkg/database.go
+++ b/pkg/database.go
@@ -1,6 +1,8 @@
 package mariadb
 
 import (
+	"strings"
+
 	util "github.com/openstack-k8s-operators/lib-common/pkg/util"
 	databasev1beta1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -22,7 +24,10 @@ func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName s
 	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      database.Spec.Name + "-database-sync",
+			// provided db name is used as metadata name where underscore is a not allowed
+			// character. lets remove all underscored that underscores in the db name are
+			// possible.
+			Name:      strings.Replace(database.Spec.Name, "_", "", -1) + "-database-sync",
 			Namespace: database.Namespace,
 			Labels:    labels,
 		},
@@ -78,7 +83,7 @@ func DeleteDbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHost
 	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      database.Spec.Name + "-database-delete",
+			Name:      strings.Replace(database.Spec.Name, "_", "", -1) + "-database-delete",
 			Namespace: database.Namespace,
 			Labels:    labels,
 		},


### PR DESCRIPTION
This is not a full polished patch, just removes the invalid
underscore character from the metadata name.