### PR TITLE
Fix race with MariaDB/MariaDBDatabase

### DIFF
--- a/controllers/mariadbdatabase_controller.go
+++ b/controllers/mariadbdatabase_controller.go
@@ -75,11 +75,10 @@ func (r *MariaDBDatabaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, er
 	objectKey, err := client.ObjectKeyFromObject(db)
 	err = r.Client.Get(context.TODO(), objectKey, db)
 	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			r.Log.Info("No DB found for label 'dbName'.")
-			return ctrl.Result{}, nil
+		if !k8s_errors.IsNotFound(err) {
+			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: time.Second * 10}, err
+		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
 	finalizerName := "mariadb-" + instance.Name

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	// logf "sigs.k8s.io/controller-runtime/pkg/log"
 	// "sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	// databasev1beta1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
@@ -48,6 +47,7 @@ func TestAPIs(t *testing.T) {
 		"Controller Suite",
 		[]Reporter{printer.NewlineReporter{}})
 }
+
 /*
 var _ = BeforeSuite(func(done Done) {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))


### PR DESCRIPTION
This resolves a race introduced in 5d6e4248 where MariaDBDatabase
objects might not get created unless the MariaDB already exists.
The issue was that reconcile was returning a nil result (thus
signalling completion) when it was supposed to be blocking
on the MariaDB to be created.