### PR TITLE
[Makefile] Update opm release page location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/${OS}-${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else


### PR DESCRIPTION
I believe '$${ARCH} and $${OS}' is a typo and it should be '${ARCH} and ${OS}'

Considering that bash variable $$ resolving into a pid rather than arch and os.