### PR TITLE
Cleanup jobs after hash is persisted

### DIFF
--- a/controllers/mariadbdatabase_controller.go
+++ b/controllers/mariadbdatabase_controller.go
@@ -121,8 +121,7 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	dbCreateJob := job.NewJob(
 		jobDef,
 		databasev1beta1.DbCreateHash,
-		false,
-		5,
+		time.Duration(5)*time.Second,
 		dbCreateHash,
 	)
 	ctrlResult, err := dbCreateJob.DoJob(
@@ -144,6 +143,10 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, err
 		}
 		r.Log.Info(fmt.Sprintf("Job %s hash added - %s", jobDef.Name, instance.Status.Hash[databasev1beta1.DbCreateHash]))
+	}
+	err = job.DeleteAllSucceededJobs(ctx, helper, []string{instance.Status.Hash[databasev1beta1.DbCreateHash]})
+	if err != nil {
+		return ctrlResult, err
 	}
 
 	// database creation finished... okay to set to completed

--- a/go.mod
+++ b/go.mod
@@ -85,3 +85,5 @@ require (
 )
 
 replace github.com/openstack-k8s-operators/mariadb-operator/api => ./api
+
+replace github.com/openstack-k8s-operators/lib-common/modules/common => github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff h1:R3q2BmVaVdvI/0/QUBO5khg7xXidsHQyKUViaFhU2t4=
+github.com/gibizer/lib-common/modules/common v0.0.0-20221014143800-c6662e4a62ff/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -374,8 +376,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221014085528-1bd40eedfb90 h1:Y2QbuhTa+7+1eUh5Bz+yLXi0m3NNA49ba5ZkVV9lTGk=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.0.0-20221014085528-1bd40eedfb90/go.mod h1:KWqK7l2ej+rIYngoNUrxE2YjKGlRAAgJXXM0uU2R6XY=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=


### PR DESCRIPTION
There was a lib-common issue where job.DoJob() deleted the Job right after it is succeeded. Then the controller tried to store the hash of the Job in Status. But if that failed (due to e.g. Conflict) then in the next Reconcile call lib-common would re-create and re-run the Job as the hash of the previous Job and the Job itself is lost.

The lib-common is fixed in a way that the automatic Job deletion is removed from DoJob() and that needs to be now done on the caller side via the new job.DeleteAllSuccededJobs() call.

This patch adapts to the new lib-common version by doing the Job cleanup right after the Status.Update() successfully persisted the Job's hash.

Depends-On: openstack-k8s-operators/lib-common#77