### PR TITLE
Rename the Job used to create the DB

### DIFF
--- a/pkg/database.go
+++ b/pkg/database.go
@@ -30,9 +30,9 @@ func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName s
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			// provided db name is used as metadata name where underscore is a not allowed
-			// character. lets remove all underscored that underscores in the db name are
+			// character. Lets replace all underscores with hypen. Underscores in the db name are
 			// possible.
-			Name:      strings.Replace(database.Spec.Name, "_", "", -1) + "-database-sync",
+			Name:      strings.Replace(database.Spec.Name, "_", "-", -1) + "-db-create",
 			Namespace: database.Namespace,
 			Labels:    labels,
 		},


### PR DESCRIPTION
Rename it from x-database-sync to x-db-create as it is not really calling db sync just creating and empty database named x. Also we are not simply dropping underscores from the name but replacing it with a hyphen to make the names more readable.