### PR TITLE
Add simple kuttl tests for mariadb

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,25 @@
+#
+# EXECUTION (from install_yamls repo root):
+#
+#   make kuttl_keystone
+#
+# ASSUMPTIONS:
+#
+# 1. Latest version of kuttl is installed at /usr/local/bin/kubectl-kuttl
+#    - wget https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+#    - mv kubectl-kuttl_0.11.1_linux_x86_64 /usr/local/bin/kubectl-kuttl
+#    - chmod 755 /usr/local/bin/kubectl-kuttl
+# 2. An OCP 4.10+ CRC cluster with Podified Operators has been deployed
+# 3. CLI user has access to $KUBECONFIG
+# 4. The environment variable INSTALL_YAMLS is set to the the path of the
+#    install_yamls repo
+
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+reportFormat: JSON
+reportName: kuttl-test-mariadb
+namespace: openstack
+timeout: 180
+parallel: 1
+suppress:
+  - events                     # Remove spammy event logs

--- a/tests/kuttl/tests/mariadb_deploy/01-assert.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/01-assert.yaml
@@ -1,0 +1,62 @@
+#
+# Check for:
+#
+# - 1 MariaDB CR
+# - 1 Pod for MariaDB CR
+#
+
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDB
+metadata:
+  name: openstack
+  namespace: openstack
+spec:
+  containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  secret: osp-secret
+  storageClass: local-storage
+  storageRequest: 500M
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Deployment completed
+    reason: Ready
+    status: "True"
+    type: DeploymentReady
+  - message: Exposing service completed
+    reason: Ready
+    status: "True"
+    type: ExposeServiceReady
+  - message: MariaDB dbinit completed
+    reason: Ready
+    status: "True"
+    type: MariaDBInitialized
+  - message: Service config create completed
+    reason: Ready
+    status: "True"
+    type: ServiceConfigReady
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    openshift.io/scc: anyuid
+  labels:
+    app: mariadb
+    cr: mariadb-openstack
+    owner: mariadb-operator
+  name: mariadb-openstack
+  namespace: openstack
+spec:
+  containers:
+  - image: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+    imagePullPolicy: IfNotPresent
+    name: mariadb
+    resources: {}
+  restartPolicy: Always
+  serviceAccount: mariadb-operator-mariadb
+  serviceAccountName: mariadb-operator-mariadb
+status:
+  phase: Running

--- a/tests/kuttl/tests/mariadb_deploy/01-deploy-mariadb.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/01-deploy-mariadb.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      PWD=$INSTALL_YAMLS
+      echo $INSTALL_YAMLS
+      make -C $INSTALL_YAMLS mariadb_deploy


### PR DESCRIPTION
Add a very simple test suite for mariadb that just tests the deployment. This test was extracted from the keystone kuttl test suite and should be expanded in a future change.