### PR TITLE
Fix missing DBMaxTimeout template parameter

### DIFF
--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -341,6 +341,8 @@ func (r *MariaDBReconciler) generateServiceConfigMaps(
 ) error {
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(mariadb.ServiceName), map[string]string{})
 	templateParameters := make(map[string]interface{})
+	// TODO: We probably need to make this configurable.
+	templateParameters["DbMaxTimeout"] = 60
 
 	// ConfigMaps for mariadb
 	cms := []util.Template{

--- a/templates/mariadb/bin/mariadb_init.sh
+++ b/templates/mariadb/bin/mariadb_init.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+set -e
 if [ -e /var/lib/mysql/mysql ]; then exit 0; fi
 #echo -e "\n[mysqld]\nwsrep_provider=none" >> /etc/my.cnf
 #kolla_set_configs
@@ -5,7 +7,7 @@ if [ -e /var/lib/mysql/mysql ]; then exit 0; fi
 mkdir -p /var/lib/mysql
 mysql_install_db
 mysqld_safe --skip-networking --wsrep-on=OFF &
-timeout {{.DBMaxTimeout}} /bin/bash -c "until mysqladmin -uroot -p'$DB_ROOT_PASSWORD' ping 2>/dev/null; do sleep 1; done"
+timeout {{.DbMaxTimeout}} /bin/bash -c "until mysqladmin -uroot -p'$DB_ROOT_PASSWORD' ping 2>/dev/null; do sleep 1; done"
 mysql -uroot -p"$DB_ROOT_PASSWORD" -e "CREATE USER 'mysql'@'localhost';"
 mysql -uroot -p"$DB_ROOT_PASSWORD" -e "REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql'@'localhost';"
-timeout {{.DBMaxTimeout}} mysqladmin -uroot -p"$DB_ROOT_PASSWORD" shutdown
+timeout {{.DbMaxTimeout}} mysqladmin -uroot -p"$DB_ROOT_PASSWORD" shutdown


### PR DESCRIPTION
The parameter was incompletely removed when we intorduced secrets[1]. This also enables -e so that we can catch any command failures.

[1] d882ed426e3164bd7c0cdd68a78c1dbdd35c161d