### PR TITLE
Remove harcoded check for storageClass in Kuttl test

### DIFF
--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -13,7 +13,6 @@ metadata:
 spec:
   containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
   secret: osp-secret
-  storageClass: local-storage
   storageRequest: 500M
 status:
   conditions:


### PR DESCRIPTION
Currently MariaDB kuttl tests check that the database is using
local-storage, but this could potentially change in the future or
between different systems, so we remove this check.
