### PR TITLE
Fix mariadb config file permissions and restart pod on config change

### DIFF
--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -72,13 +72,13 @@ type MariaDBReconciler struct {
 
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbs/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbs/finalizers,verbs=update
-// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete;
-// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;create;update;delete;
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;delete;
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;delete;
-// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete;
-// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete;
+// +kubebuilder:rbac:groups=mariadb.openstack.org,resources=mariadbs/finalizers,verbs=update;patch
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete;patch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete;patch
 
 // Reconcile reconcile mariadb API requests
 func (r *MariaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -295,6 +295,16 @@ func (r *MariaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	op, err = controllerutil.CreateOrPatch(ctx, r.Client, pod, func() error {
 		pod.Spec.Containers[0].Image = instance.Spec.ContainerImage
+		pod.Spec.Containers[0].Env = []corev1.EnvVar{
+			{
+				Name:  "KOLLA_CONFIG_STRATEGY",
+				Value: "COPY_ALWAYS",
+			},
+			{
+				Name:  "CONFIG_HASH",
+				Value: configHash,
+			},
+		}
 		err := controllerutil.SetControllerReference(instance, pod, r.Scheme)
 		if err != nil {
 			return err

--- a/templates/mariadb/bin/config.json
+++ b/templates/mariadb/bin/config.json
@@ -4,7 +4,7 @@
         {
             "source": "/var/lib/config-data/galera.cnf",
             "dest": "/etc/my.cnf.d/galera.cnf",
-            "owner": "root",
+            "owner": "mysql",
             "perm": "0600"
         }
     ]

--- a/templates/mariadb/bin/galera.cnf
+++ b/templates/mariadb/bin/galera.cnf
@@ -7,7 +7,7 @@ key_buffer_size = 16M
 
 [mysqld]
 basedir = /usr
-bind-address = 127.0.0.1
+bind-address = *
 datadir = /var/lib/mysql
 expire_logs_days = 10
 innodb_file_per_table = ON

--- a/templates/mariadb/bin/init_config.json
+++ b/templates/mariadb/bin/init_config.json
@@ -4,7 +4,7 @@
         {
             "source": "/var/lib/config-data/galera.cnf",
             "dest": "/etc/my.cnf.d/galera.cnf",
-            "owner": "root",
+            "owner": "mysql",
             "perm": "0600"
         },
         {


### PR DESCRIPTION
Mariadb is using default conf as the conf file is not readable by the mysql user. Also pass the config hash as an env to the pod to ensure it is recreated when the config changes.