### PR TITLE
Fix resource labels and selector in associated services

### DIFF
--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -246,8 +246,7 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	// the headless service provides DNS entries for pods
 	// the name of the resource must match the name of the app selector
-	adoptionSelector := mariadb.ResourceName(instance.Name)
-	pkghl := mariadb.HeadlessService(instance, adoptionSelector)
+	pkghl := mariadb.HeadlessService(instance)
 	headless := &corev1.Service{ObjectMeta: pkghl.ObjectMeta}
 	op, err := controllerutil.CreateOrPatch(ctx, r.Client, headless, func() error {
 		headless.Spec = pkghl.Spec
@@ -264,7 +263,7 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		r.Log.Info(fmt.Sprintf("%s %s database headless service %s - operation: %s", instance.Kind, instance.Name, headless.Name, string(op)))
 	}
 
-	pkgsvc := mariadb.ServiceForAdoption(instance, adoption, adoptionSelector)
+	pkgsvc := mariadb.ServiceForAdoption(instance, "galera", adoption)
 	service := &corev1.Service{ObjectMeta: pkgsvc.ObjectMeta}
 	op, err = controllerutil.CreateOrPatch(ctx, r.Client, service, func() error {
 		service.Spec = pkgsvc.Spec

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -19,14 +19,21 @@ func ServiceLabels(database metav1.Object) map[string]string {
 	})
 }
 
+// LabelSelectors - labels for service, match statefulset and service should match
+func LabelSelectors(database metav1.Object, dbType string) map[string]string {
+	return map[string]string{
+		"app": dbType,
+		"cr":  dbType + "-" + database.GetName(),
+	}
+}
+
 // StatefulSetLabels - labels for statefulset, match service labels
 func StatefulSetLabels(database metav1.Object) map[string]string {
 	name := database.GetName()
-	return labels.GetLabels(database, "mariadb", map[string]string{
-		"owner":     "mariadb-operator",
-		"app":       StatefulSetName(name),
-		"cr":        "mariadb-" + name,
-		"galera_cr": name,
+	return labels.GetLabels(database, "galera", map[string]string{
+		"owner": "mariadb-operator",
+		"app":   "galera",
+		"cr":    "galera-" + name,
 	})
 }
 


### PR DESCRIPTION
When creating multiple mariadb or galera CRs in the same environment the associated services all have the same label selectors, which make pods show up as endpoints on the wrong services.

Fix that by reworking the labels associated to pods/statefulsets, and tweak the selectors in the service to only target the expected resources.