### PR TITLE
galera: Support additional custom config file

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -55,6 +55,11 @@ spec:
                 default: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
                 description: Name of the galera container image to run
                 type: string
+              customServiceConfig:
+                description: Customize config using this parameter to change service
+                  defaults, or overwrite rendered information using raw MariaDB config
+                  format. The content gets added to /etc/my.cnf.d/galera_custom.cnf
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -153,11 +158,16 @@ spec:
                   - type
                   type: object
                 type: array
+              configHash:
+                default: ""
+                description: Hash of the configuration files
+                type: string
               safeToBootstrap:
                 description: Name of the node that can safely bootstrap a cluster
                 type: string
             required:
             - bootstrapped
+            - configHash
             type: object
         type: object
     served: true

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -21,6 +21,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// CustomServiceConfigFile name of the additional mariadb config file
+	CustomServiceConfigFile = "galera_custom.cnf.in"
+)
+
 // GaleraSpec defines the desired state of Galera
 type GaleraSpec struct {
 	// Name of the secret to look for password keys
@@ -44,6 +49,11 @@ type GaleraSpec struct {
 	// NodeSelector to target subset of worker nodes running this service
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// +kubebuilder:validation:Optional
+	// Customize config using this parameter to change service defaults,
+	// or overwrite rendered information using raw MariaDB config format.
+	// The content gets added to /etc/my.cnf.d/galera_custom.cnf
+	CustomServiceConfig string `json:"customServiceConfig,omitempty"`
+	// +kubebuilder:validation:Optional
 	// Adoption configuration
 	AdoptionRedirect AdoptionRedirectSpec `json:"adoptionRedirect"`
 }
@@ -65,6 +75,9 @@ type GaleraStatus struct {
 	// Is the galera cluster currently running
 	// +kubebuilder:default=false
 	Bootstrapped bool `json:"bootstrapped"`
+	// Hash of the configuration files
+	// +kubebuilder:default=""
+	ConfigHash string `json:"configHash"`
 	// Deployment Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 }

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -55,6 +55,11 @@ spec:
                 default: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
                 description: Name of the galera container image to run
                 type: string
+              customServiceConfig:
+                description: Customize config using this parameter to change service
+                  defaults, or overwrite rendered information using raw MariaDB config
+                  format. The content gets added to /etc/my.cnf.d/galera_custom.cnf
+                type: string
               nodeSelector:
                 additionalProperties:
                   type: string
@@ -153,11 +158,16 @@ spec:
                   - type
                   type: object
                 type: array
+              configHash:
+                default: ""
+                description: Hash of the configuration files
+                type: string
               safeToBootstrap:
                 description: Name of the node that can safely bootstrap a cluster
                 type: string
             required:
             - bootstrapped
+            - configHash
             type: object
         type: object
     served: true

--- a/config/samples/mariadb_v1beta1_galera_custom_config.yaml
+++ b/config/samples/mariadb_v1beta1_galera_custom_config.yaml
@@ -1,0 +1,13 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: openstack
+spec:
+  secret: mariadb-secret
+  storageClass: local-storage
+  storageRequest: 500M
+  containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  replicas: 3
+  customServiceConfig: |
+    [mysqld]
+    max_connections = 8192

--- a/pkg/statefulset.go
+++ b/pkg/statefulset.go
@@ -18,6 +18,7 @@ func StatefulSet(g *mariadbv1.Galera) *appsv1.StatefulSet {
 	runAsUser := int64(0)
 	storage := g.Spec.StorageClass
 	storageRequest := resource.MustParse(g.Spec.StorageRequest)
+	configHash := g.Status.ConfigHash
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -86,6 +87,9 @@ func StatefulSet(g *mariadbv1.Galera) *appsv1.StatefulSet {
 						Name:    "galera",
 						Command: []string{"/usr/bin/dumb-init", "--", "/usr/local/bin/kolla_start"},
 						Env: []corev1.EnvVar{{
+							Name:  "CR_CONFIG_HASH",
+							Value: configHash,
+						}, {
 							Name:  "KOLLA_CONFIG_STRATEGY",
 							Value: "COPY_ALWAYS",
 						}, {
@@ -204,6 +208,10 @@ func StatefulSet(g *mariadbv1.Galera) *appsv1.StatefulSet {
 										{
 											Key:  "galera.cnf.in",
 											Path: "galera.cnf.in",
+										},
+										{
+											Key:  mariadbv1.CustomServiceConfigFile,
+											Path: mariadbv1.CustomServiceConfigFile,
 										},
 									},
 								},

--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -2,7 +2,14 @@
 set +eux
 PODNAME=$(hostname -f | cut -d. -f1,2)
 PODIP=$(grep "${PODNAME}" /etc/hosts | cut -d$'\t' -f1)
-sed -e "s/{ PODNAME }/${PODNAME}/" -e "s/{ PODIP }/${PODIP}/" /var/lib/config-data/galera.cnf.in > /var/lib/pod-config-data/galera.cnf
+pushd /var/lib/config-data
+for cfg in *.cnf.in; do
+    if [ -s "${cfg}" ]; then
+	echo "Generating config file from template ${cfg}"
+	sed -e "s/{ PODNAME }/${PODNAME}/" -e "s/{ PODIP }/${PODIP}/" "/var/lib/config-data/${cfg}" > "/var/lib/pod-config-data/${cfg%.in}"
+    fi
+done
+popd
 if [ -e /var/lib/mysql/mysql ]; then
     echo -e "Database already bootstrapped"
     exit 0

--- a/templates/galera/config/config.json
+++ b/templates/galera/config/config.json
@@ -2,10 +2,11 @@
     "command": "/usr/local/bin/detect_gcomm_and_start.sh",
     "config_files": [
         {
-            "source": "/var/lib/pod-config-data/galera.cnf",
-            "dest": "/etc/my.cnf.d/galera.cnf",
+            "source": "/var/lib/pod-config-data",
+            "dest": "/etc/my.cnf.d",
             "owner": "root",
-            "perm": "0600"
+            "perm": "0600",
+            "merge": "true"
         },
         {
             "source": "/var/lib/operator-scripts",


### PR DESCRIPTION
This allows a Galera CR to override or pass new configuration variables for the MariaDB server or the CLI. A new field CustomServiceConfig contains raw MariaDB config statements, which are ultimately stored in /etc/my.cnf.d/galera_custom.cnf and processed after the usual galera.cnf.

Updating CustomServiceConfig triggers a rolling restart of the galera pods, without service disruption.