### PR TITLE
mariadb: allow mysqld to set max_connections at startup

### DIFF
--- a/pkg/pod.go
+++ b/pkg/pod.go
@@ -9,6 +9,7 @@ import (
 // Pod -
 func Pod(db *databasev1beta1.MariaDB, configHash string) *corev1.Pod {
 
+	runAsUser := int64(0)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mariadb-" + db.Name,
@@ -21,6 +22,9 @@ func Pod(db *databasev1beta1.MariaDB, configHash string) *corev1.Pod {
 				{
 					Name:  "mariadb",
 					Image: db.Spec.ContainerImage,
+					SecurityContext: &corev1.SecurityContext{
+						RunAsUser: &runAsUser,
+					},
 					Env: []corev1.EnvVar{
 						{
 							Name:  "KOLLA_CONFIG_STRATEGY",


### PR DESCRIPTION
Mariadb pods are started as user mysql, which has no specific right to configure file descriptor limits. This prevents the server from honoring the requested max_connections of 4096.

Make the pod start mysqld as root, and let the mysqld server drop privileges to user mysql explicitly. This way, the server can configure limits prior to accepting connections.