### PR TITLE
galera: fix permissions of config files

### DIFF
--- a/templates/galera/config/config.json
+++ b/templates/galera/config/config.json
@@ -2,11 +2,17 @@
     "command": "/usr/local/bin/detect_gcomm_and_start.sh",
     "config_files": [
         {
-            "source": "/var/lib/pod-config-data",
-            "dest": "/etc/my.cnf.d",
+            "source": "/var/lib/pod-config-data/galera.cnf",
+            "dest": "/etc/my.cnf.d/galera.cnf",
             "owner": "root",
-            "perm": "0600",
-            "merge": "true"
+            "perm": "0644"
+        },
+        {
+            "source": "/var/lib/pod-config-data/galera_custom.cnf",
+            "dest": "/etc/my.cnf.d/galera_custom.cnf",
+            "owner": "root",
+            "perm": "0644",
+            "optional": true
         },
         {
             "source": "/var/lib/operator-scripts",


### PR DESCRIPTION
Since [1] the kolla config incorrectly sets permissions of the mysql config directory to be accessible by root only. Fix read access for all users, and align the permissions on the config files as well.

[1] 751b510968ab82fe5dd61b2198fb5cd30df0427e