### PR TITLE
Allow mariadb controller to patch pods

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -81,6 +81,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -76,7 +76,7 @@ type MariaDBReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;delete;
 // +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;create;update;delete;
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;delete;
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;delete;
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete;
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete;
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;delete;
 


### PR DESCRIPTION
The mariadb controller should be able to patch pods, for example when the mariadb service container image is updated. This fixes the missing rbac.