### PR TITLE
Add revive to golanci

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,17 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errorlint
+    - revive
+    - gofmt
+    - govet
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: true
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,31 +1,6 @@
 repos:
 - repo: local
   hooks:
-    - id: golangci-lint
-      name: golangci-lint
-      language: golang
-      types: [go]
-      entry: make
-      args: ["golangci-lint"]
-      pass_filenames: false
-    - id: golint
-      name: golint
-      language: system
-      entry: make
-      args: ["golint"]
-      pass_filenames: false
-    - id: gofmt
-      name: gofmt
-      language: system
-      entry: make
-      args: ["fmt"]
-      pass_filenames: false
-    - id: govet
-      name: govet
-      language: system
-      entry: make
-      args: ["vet"]
-      pass_filenames: false
     - id: gotidy
       name: gotidy
       language: system
@@ -80,3 +55,9 @@ repos:
   hooks:
     - id: bashate
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
+
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.52.2
+  hooks:
+    - id: golangci-lint
+      args: ["-v"]

--- a/Makefile
+++ b/Makefile
@@ -104,11 +104,9 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: tidy
-tidy:
-	go mod tidy; \
-	pushd "$(LOCALBIN)/../api"; \
-	go mod tidy; \
-	popd
+tidy: ## Run go mod tidy on every mod file in the repo
+	go mod tidy
+	cd ./api && go mod tidy
 
 .PHONY: golangci-lint
 golangci-lint:

--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -283,7 +283,7 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 			condition.SeverityWarning,
 			condition.ServiceConfigReadyErrorMessage,
 			err.Error()))
-		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %w", err)
 	}
 	// From hereon, configMapVars holds a hash of the config generated for this instance
 	// This is used in an envvar in the statefulset to restart it on config change

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -238,7 +238,7 @@ func (r *MariaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			condition.SeverityWarning,
 			condition.ServiceConfigReadyErrorMessage,
 			err.Error()))
-		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error calculating configmap hash: %w", err)
 	}
 	mergedMapVars := env.MergeEnvs([]corev1.EnvVar{}, configMapVars)
 	configHash := ""

--- a/hack/configure_local_webhook.sh
+++ b/hack/configure_local_webhook.sh
@@ -12,16 +12,16 @@ sudo firewall-cmd --runtime-to-permanent
 
 # Generate the certs and the ca bundle
 if [ "$SKIP_CERT" = false ] ; then
-  mkdir -p ${TMPDIR}
-  rm -rf ${TMPDIR}/* || true
+    mkdir -p ${TMPDIR}
+    rm -rf ${TMPDIR}/* || true
 
-  openssl req -newkey rsa:2048 -days 3650 -nodes -x509 \
-    -subj "/CN=${HOSTNAME}" \
-    -addext "subjectAltName = IP:${CRC_IP}" \
-    -keyout ${TMPDIR}/tls.key \
-    -out ${TMPDIR}/tls.crt
+    openssl req -newkey rsa:2048 -days 3650 -nodes -x509 \
+        -subj "/CN=${HOSTNAME}" \
+        -addext "subjectAltName = IP:${CRC_IP}" \
+        -keyout ${TMPDIR}/tls.key \
+        -out ${TMPDIR}/tls.crt
 
-  cat ${TMPDIR}/tls.crt ${TMPDIR}/tls.key | base64 -w 0 > ${TMPDIR}/bundle.pem
+    cat ${TMPDIR}/tls.crt ${TMPDIR}/tls.key | base64 -w 0 > ${TMPDIR}/bundle.pem
 
 fi
 

--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -5,8 +5,8 @@ PODIP=$(grep "${PODNAME}" /etc/hosts | cut -d$'\t' -f1)
 pushd /var/lib/config-data
 for cfg in *.cnf.in; do
     if [ -s "${cfg}" ]; then
-	echo "Generating config file from template ${cfg}"
-	sed -e "s/{ PODNAME }/${PODNAME}/" -e "s/{ PODIP }/${PODIP}/" "/var/lib/config-data/${cfg}" > "/var/lib/pod-config-data/${cfg%.in}"
+        echo "Generating config file from template ${cfg}"
+        sed -e "s/{ PODNAME }/${PODNAME}/" -e "s/{ PODIP }/${PODIP}/" "/var/lib/config-data/${cfg}" > "/var/lib/pod-config-data/${cfg%.in}"
     fi
 done
 popd


### PR DESCRIPTION
This PR replace deprecated go-linter using
revive (https://golangci-lint.run/usage/linters/#revive).

We will add "ginkgolinter" in follow up patch once we merged add pre-commit job in openshift/releases.

If we add "ginkgolinter" in this patch then it's causes below issue [1]

```
level=info msg="[config_reader] Config search paths: [./ /home/prow/go/src/github.com/openstack-k8s-operators/dataplane-operator /home/prow/go/src/github.com/openstack-k8s-operators /home/prow/go/src/github.com /home/prow/go/src /home/prow/go /home/prow /home /]"
level=info msg="[config_reader] Used config file .golangci.yaml"
level=error msg="Running error: unknown linters: 'ginkgolinter', run 'golangci-lint help linters' to see the list of supported linters"
```

This patch also Remove fmt dependency from make tidy as per [2]:

The fmt dependency cannot be run if the go.mod file needs an update:
```
 $ make tidy
 go fmt ./...
 go: updates to go.mod needed; to update it:
        go mod tidy
 make: *** [Makefile:103: fmt] Error 1
```

I have also made some changes as per the comment given here [3]

[1]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openstack-k8s-operators_dataplane-operator/147/pull-ci-openstack-k8s-operators-dataplane-operator-main-golangci/1643555465537261568/artifacts/test/build-log.txt 
[2]: https://github.com/openstack-k8s-operators/placement-operator/pull/153
[3]: https://github.com/openstack-k8s-operators/cinder-operator/pull/147#discussion_r1158504341
