### PR TITLE
galera: improve recovery of pods

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -99,8 +99,12 @@ spec:
                   description: GaleraAttributes holds startup information for a Galera
                     host
                   properties:
+                    containerID:
+                      description: Identifier of the container at the time the gcomm
+                        URI was injected
+                      type: string
                     gcomm:
-                      description: URI used to connect to the galera cluster
+                      description: Gcomm URI used to connect to the galera cluster
                       type: string
                     seqno:
                       description: Last recorded replication sequence number in the

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -61,8 +61,10 @@ type GaleraSpec struct {
 type GaleraAttributes struct {
 	// Last recorded replication sequence number in the DB
 	Seqno string `json:"seqno"`
-	// URI used to connect to the galera cluster
+	// Gcomm URI used to connect to the galera cluster
 	Gcomm string `json:"gcomm,omitempty"`
+	// Identifier of the container at the time the gcomm URI was injected
+	ContainerID string `json:"containerID,omitempty"`
 }
 
 // GaleraStatus defines the observed state of Galera

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -99,8 +99,12 @@ spec:
                   description: GaleraAttributes holds startup information for a Galera
                     host
                   properties:
+                    containerID:
+                      description: Identifier of the container at the time the gcomm
+                        URI was injected
+                      type: string
                     gcomm:
-                      description: URI used to connect to the galera cluster
+                      description: Gcomm URI used to connect to the galera cluster
                       type: string
                     seqno:
                       description: Last recorded replication sequence number in the


### PR DESCRIPTION
The mariadb operator determines whether a starting pod will bootstrap a galera cluster or join an existing one. On startup, the galera pod receives that information via a temporary file injected by the operator. Once galera is running in the pod, the operator updates its status.

Improve the status tracking so that the operator can detect when a pod failed to start galera, and try again in a subsequent reconcile loop.

Also make sure that the operator cannot inspect the galera state while the galera server is being started, to prevent any corruption.