### PR TITLE
Ctrl manager labels for webhooks and logging

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: mariadb-controller-manager
+    control-plane: controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,20 +11,20 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: mariadb-controller-manager
+    control-plane: controller-manager
     app.kubernetes.io/name: mariadb-operator
     app.kubernetes.io/component: mariadb
 spec:
   selector:
     matchLabels:
-      control-plane: mariadb-controller-manager
+      app.kubernetes.io/name: mariadb-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: mariadb-controller-manager
+        control-plane: controller-manager
         app.kubernetes.io/name: mariadb-operator
         app.kubernetes.io/component: mariadb
     spec:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: mariadb-controller-manager
+    control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: mariadb-controller-manager
+      app.kubernetes.io/name: mariadb-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: mariadb-controller-manager
+    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: mariadb-controller-manager
+    app.kubernetes.io/name: mariadb-operator

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: mariadb-controller-manager
+    app.kubernetes.io/name: mariadb-operator


### PR DESCRIPTION
For initial webhook work, we found that we needed to remove the `control-plane: controller-manager` label and label-selector from the `controller-manager` pod and its associated peripherals in order to properly direct webhook traffic to the appropriate webhook server for our various operators' CRDs.  This had the unfortunate side effect of removing a label that could be used for bulk-selecting all our `controller-manager` pods.  This was noted here [1].  We therefore have opted to reintroduce the `control-plane: controller-manager` default label (originally added by `operator-sdk` scaffolding) and instead use another unique label (also added by `operator-sdk` scaffolding, at least in newer version of `operator-sdk`) for routing webhook traffic.  This unique label takes the form of `app.kubernetes.io/name: <operator name>` and can be used with label-selectors to ensure webhooks and other peripheral k8s services work correctly.

[1] https://github.com/openshift/release/pull/37084#discussion_r1138314478