### PR TITLE
Remove install_yamls dependency for kuttl tests

### DIFF
--- a/tests/kuttl/tests/mariadb_deploy/01-deploy-mariadb.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/01-deploy-mariadb.yaml
@@ -2,6 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      PWD=$INSTALL_YAMLS
-      echo $INSTALL_YAMLS
-      make -C $INSTALL_YAMLS mariadb_deploy
+      cp ../../../../config/samples/mariadb_v1beta1_mariadb.yaml deploy
+      oc kustomize deploy | oc apply -n openstack -f -

--- a/tests/kuttl/tests/mariadb_deploy/02-cleanup-mariadb.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/02-cleanup-mariadb.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      oc kustomize deploy | oc delete -n openstack -f -
+      rm deploy/mariadb_v1beta1_mariadb.yaml

--- a/tests/kuttl/tests/mariadb_deploy/02-errors.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/02-errors.yaml
@@ -1,0 +1,19 @@
+#
+# Check for:
+#
+# - No MariaDB CR
+# - No Pod for MariaDB CR
+
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDB
+metadata:
+  name: openstack
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: mariadb
+    cr: mariadb-openstack
+    owner: mariadb-operator
+  name: mariadb-openstack

--- a/tests/kuttl/tests/mariadb_deploy/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/deploy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./mariadb_v1beta1_mariadb.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/secret
+      value: osp-secret
+  target:
+    kind: MariaDB


### PR DESCRIPTION
Instead of using install_yamls targets for deploying and cleaning up
mariadb, use the CR sample from config/samples. This removes a possible
circular dependency issue when using install_yamls to run the jobs and
to run some test steps.
