### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ gowork: ## Generate go.work file
 # $oc delete -n openstack mutatingwebhookconfiguration/mmariadb.kb.io
 SKIP_CERT ?=false
 .PHONY: run-with-webhook
-run-with-webhook: export MARIADB_IMAGE_URL_DEFAULT=quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+run-with-webhook: export MARIADB_IMAGE_URL_DEFAULT=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 run-with-webhook: export METRICS_PORT?=8080
 run-with-webhook: export HEALTH_PORT?=8081
 run-with-webhook: export OPERATOR_TEMPLATES=./templates/

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,4 +12,4 @@ spec:
       - name: manager
         env:
         - name: MARIADB_IMAGE_URL_DEFAULT
-          value: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified

--- a/config/samples/mariadb_v1beta1_galera.yaml
+++ b/config/samples/mariadb_v1beta1_galera.yaml
@@ -6,5 +6,5 @@ spec:
   secret: mariadb-secret
   storageClass: local-storage
   storageRequest: 500M
-  containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   replicas: 3

--- a/config/samples/mariadb_v1beta1_galera_custom_config.yaml
+++ b/config/samples/mariadb_v1beta1_galera_custom_config.yaml
@@ -6,7 +6,7 @@ spec:
   secret: mariadb-secret
   storageClass: local-storage
   storageRequest: 500M
-  containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   replicas: 3
   customServiceConfig: |
     [mysqld]

--- a/config/samples/mariadb_v1beta1_mariadb.yaml
+++ b/config/samples/mariadb_v1beta1_mariadb.yaml
@@ -6,4 +6,4 @@ spec:
   secret: mariadb-secret
   storageClass: local-storage
   storageRequest: 500M
-  containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   name: openstack
   namespace: openstack
 spec:
-  containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   secret: osp-secret
   storageRequest: 500M
 status:
@@ -50,7 +50,7 @@ metadata:
   namespace: openstack
 spec:
   containers:
-  - image: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  - image: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
     imagePullPolicy: IfNotPresent
     name: mariadb
     resources: {}


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib