### PR TITLE
galera: do not require root user to init/run pods

### DIFF
--- a/pkg/statefulset.go
+++ b/pkg/statefulset.go
@@ -15,7 +15,6 @@ func StatefulSet(g *mariadbv1.Galera) *appsv1.StatefulSet {
 	ls := StatefulSetLabels(g)
 	name := StatefulSetName(g.Name)
 	replicas := g.Spec.Replicas
-	runAsUser := int64(0)
 	storage := g.Spec.StorageClass
 	storageRequest := resource.MustParse(g.Spec.StorageRequest)
 	configHash := g.Status.ConfigHash
@@ -41,9 +40,6 @@ func StatefulSet(g *mariadbv1.Galera) *appsv1.StatefulSet {
 						Image:   g.Spec.ContainerImage,
 						Name:    "mysql-bootstrap",
 						Command: []string{"bash", "/var/lib/operator-scripts/mysql_bootstrap.sh"},
-						SecurityContext: &corev1.SecurityContext{
-							RunAsUser: &runAsUser,
-						},
 						Env: []corev1.EnvVar{{
 							Name:  "KOLLA_BOOTSTRAP",
 							Value: "True",
@@ -103,9 +99,6 @@ func StatefulSet(g *mariadbv1.Galera) *appsv1.StatefulSet {
 								},
 							},
 						}},
-						SecurityContext: &corev1.SecurityContext{
-							RunAsUser: &runAsUser,
-						},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 3306,
 							Name:          "mysql",

--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -1,19 +1,29 @@
 #!/bin/bash
 set +eux
+
+if [ -e /var/lib/mysql/mysql ]; then
+    echo -e "Database already exists. Reuse it."
+else
+    echo -e "Creating new mariadb database."
+    # we need the right perm on the persistent directory,
+    # so use Kolla to set it up before bootstrapping the DB
+    cat <<EOF >/var/lib/pod-config-data/galera.cnf
+[mysqld]
+bind_address=localhost
+wsrep_provider=none
+EOF
+    sudo -E kolla_set_configs
+    kolla_extend_start
+fi
+
+# Generate the mariadb configs from the templates, these will get
+# copied by `kolla_start` when the pod's main container will start
 PODNAME=$(hostname -f | cut -d. -f1,2)
 PODIP=$(grep "${PODNAME}" /etc/hosts | cut -d$'\t' -f1)
-pushd /var/lib/config-data
+cd /var/lib/config-data
 for cfg in *.cnf.in; do
     if [ -s "${cfg}" ]; then
         echo "Generating config file from template ${cfg}"
         sed -e "s/{ PODNAME }/${PODNAME}/" -e "s/{ PODIP }/${PODIP}/" "/var/lib/config-data/${cfg}" > "/var/lib/pod-config-data/${cfg%.in}"
     fi
 done
-popd
-if [ -e /var/lib/mysql/mysql ]; then
-    echo -e "Database already bootstrapped"
-    exit 0
-fi
-echo -e "\n[mysqld]\nwsrep_provider=none" >> /etc/my.cnf
-kolla_set_configs
-sudo -u mysql -E kolla_extend_start

--- a/templates/galera/bin/mysql_probe.sh
+++ b/templates/galera/bin/mysql_probe.sh
@@ -1,23 +1,27 @@
 #!/bin/bash
-set -eux
+set -eu
 
 # This secret is mounted by k8s and always up to date
 read -s -u 3 3< /var/lib/secrets/dbpassword MYSQL_PWD || true
 export MYSQL_PWD
 
+PROBE_USER=root
+
 # Consider the pod has "started" once mysql is reachable
 if [ "$1" = "startup" ]; then
-    mysql -sNe "select(1);"
+    mysql -u${PROBE_USER} -sNe "select(1);"
     exit $?
 fi
+
+set -x
 
 case "$1" in
     readiness)
         # If the node is e.g. a donor, it cannot serve traffic
-        mysql -sNe "show status like 'wsrep_local_state_comment';" | grep -w -e Synced;;
+        mysql -u${PROBE_USER} -sNe "show status like 'wsrep_local_state_comment';" | grep -w -e Synced;;
     liveness)
         # If the node is not in the primary partition, restart it
-        mysql -sNe "show status like 'wsrep_cluster_status';" | grep -w -e Primary;;
+        mysql -u${PROBE_USER} -sNe "show status like 'wsrep_cluster_status';" | grep -w -e Primary;;
     *)
         echo "Invalid probe option '$1'"
         exit 1;;


### PR DESCRIPTION
The galera pods are configured to run as root so that Kolla can copy config files and bootstrap a database. Later, mysqld drops privileges by switching to user mysql via setuid().

Do not explicitely require the root user and use sudo rights instead. This works because Kolla is already allowed to sudo, and the mysqld server can set limits (e.g. file descriptors, sockets) without requiring root privileges.