### PR TITLE
Use automatically generated namespace for kuttl tests

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -18,8 +18,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 reportFormat: JSON
 reportName: kuttl-test-mariadb
-namespace: openstack
 timeout: 180
-parallel: 1
+parallel: 2
 suppress:
   - events                     # Remove spammy event logs

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -9,7 +9,6 @@ apiVersion: mariadb.openstack.org/v1beta1
 kind: MariaDB
 metadata:
   name: openstack
-  namespace: openstack
 spec:
   containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   secret: osp-secret
@@ -59,7 +58,6 @@ metadata:
     cr: mariadb-openstack
     owner: mariadb-operator
   name: mariadb-openstack
-  namespace: openstack
 spec:
   containers:
   - image: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified

--- a/tests/kuttl/common/create_secret.yaml
+++ b/tests/kuttl/common/create_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: osp-secret
+stringData:
+  DbRootPassword: "12345678"
+  DatabasePassword: "12345678"

--- a/tests/kuttl/tests/galera_deploy/00-create-secret.yaml
+++ b/tests/kuttl/tests/galera_deploy/00-create-secret.yaml
@@ -1,0 +1,1 @@
+../../common/create_secret.yaml

--- a/tests/kuttl/tests/galera_deploy/01-assert.yaml
+++ b/tests/kuttl/tests/galera_deploy/01-assert.yaml
@@ -11,19 +11,17 @@ apiVersion: mariadb.openstack.org/v1beta1
 kind: Galera
 metadata:
   name: openstack
-  namespace: openstack
 spec:
   secret: osp-secret
   storageClass: local-storage
   storageRequest: 500M
-  containerImage: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   replicas: 3
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: openstack-galera
-  namespace: openstack
 spec:
   replicas: 3
   selector:
@@ -31,7 +29,6 @@ spec:
       app: galera
       cr: galera-openstack
       galera/name: openstack
-      galera/namespace: openstack
   serviceName: openstack-galera
   template:
     metadata:
@@ -39,14 +36,13 @@ spec:
         app: galera
         cr: galera-openstack
         galera/name: openstack
-        galera/namespace: openstack
     spec:
       containers:
       - command:
         - /usr/bin/dumb-init
         - --
         - /usr/local/bin/kolla_start
-        image: quay.io/tripleozedcentos9/openstack-mariadb:current-tripleo
+        image: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
         name: galera
         ports:
         - containerPort: 3306
@@ -66,25 +62,21 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: openstack-galera-0
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   name: openstack-galera-1
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   name: openstack-galera-2
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: openstack-galera
-  namespace: openstack
 spec:
   ports:
   - name: mysql
@@ -99,10 +91,8 @@ apiVersion: v1
 kind: Endpoints
 metadata:
   name: openstack-galera
-  namespace: openstack
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: openstack-config-data
-  namespace: openstack

--- a/tests/kuttl/tests/galera_deploy/01-deploy_galera.yaml
+++ b/tests/kuttl/tests/galera_deploy/01-deploy_galera.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
   - script: |
       cp ../../../../config/samples/mariadb_v1beta1_galera.yaml deploy
-      oc kustomize deploy | oc apply -n openstack -f -
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/galera_deploy/02-scale_down_galera.yaml
+++ b/tests/kuttl/tests/galera_deploy/02-scale_down_galera.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc patch galera -n openstack openstack --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":1}]'
+      oc patch galera -n $NAMESPACE openstack --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":1}]'

--- a/tests/kuttl/tests/galera_deploy/03-cleanup_galera.yaml
+++ b/tests/kuttl/tests/galera_deploy/03-cleanup_galera.yaml
@@ -2,7 +2,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      echo $NAMESPACE
-      oc kustomize deploy | oc delete -n openstack -f -
+      oc kustomize deploy | oc delete -n $NAMESPACE -f -
       rm deploy/mariadb_v1beta1_galera.yaml
       oc delete -n $NAMESPACE pvc mysql-db-openstack-galera-0 mysql-db-openstack-galera-1 mysql-db-openstack-galera-2

--- a/tests/kuttl/tests/galera_deploy/03-errors.yaml
+++ b/tests/kuttl/tests/galera_deploy/03-errors.yaml
@@ -11,46 +11,38 @@ apiVersion: mariadb.openstack.org/v1beta1
 kind: Galera
 metadata:
   name: openstack
-  namespace: openstack
 ---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: openstack-galera
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   name: openstack-galera-0
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   name: openstack-galera-1
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   name: openstack-galera-2
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: openstack-galera
-  namespace: openstack
 ---
 apiVersion: v1
 kind: Endpoints
 metadata:
   name: openstack-galera
-  namespace: openstack
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: openstack-config-data
-  namespace: openstack

--- a/tests/kuttl/tests/mariadb_deploy/00-create-secret.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/00-create-secret.yaml
@@ -1,0 +1,1 @@
+../../common/create_secret.yaml

--- a/tests/kuttl/tests/mariadb_deploy/01-deploy-mariadb.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/01-deploy-mariadb.yaml
@@ -3,4 +3,4 @@ kind: TestStep
 commands:
   - script: |
       cp ../../../../config/samples/mariadb_v1beta1_mariadb.yaml deploy
-      oc kustomize deploy | oc apply -n openstack -f -
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/mariadb_deploy/02-cleanup-mariadb.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/02-cleanup-mariadb.yaml
@@ -2,5 +2,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      oc kustomize deploy | oc delete -n openstack -f -
+      oc kustomize deploy | oc delete -n $NAMESPACE -f -
       rm deploy/mariadb_v1beta1_mariadb.yaml


### PR DESCRIPTION
After recent changes in dynamic service account, since mariadb can be
deployed in any namespace, this change modifies the way the kuttl tests
are run, so they run in a namespace automatically created (and deleted) by
kuttl. This allows us to run the kuttl tests in a cluster where we have
already a deployed instance, without interfering. Additionally, we get
the benefit of being able to run multiple tests in parallel, since each
runs in its own namespace, which also reduces the runtime.
