### PR TITLE
Remove unused status.safeToBootstrap

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -166,9 +166,6 @@ spec:
                 default: ""
                 description: Hash of the configuration files
                 type: string
-              safeToBootstrap:
-                description: Name of the node that can safely bootstrap a cluster
-                type: string
             required:
             - bootstrapped
             - configHash

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -71,8 +71,6 @@ type GaleraAttributes struct {
 type GaleraStatus struct {
 	// A map of database node attributes for each pod
 	Attributes map[string]GaleraAttributes `json:"attributes,omitempty"`
-	// Name of the node that can safely bootstrap a cluster
-	SafeToBootstrap string `json:"safeToBootstrap,omitempty"`
 	// Is the galera cluster currently running
 	// +kubebuilder:default=false
 	Bootstrapped bool `json:"bootstrapped"`

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -166,9 +166,6 @@ spec:
                 default: ""
                 description: Hash of the configuration files
                 type: string
-              safeToBootstrap:
-                description: Name of the node that can safely bootstrap a cluster
-                type: string
             required:
             - bootstrapped
             - configHash

--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -219,10 +219,6 @@ func retrieveSequenceNumber(ctx context.Context, helper *helper.Helper, config *
 // clearPodAttributes clears information known by the operator about a pod
 func clearPodAttributes(instance *mariadbv1.Galera, podName string) {
 	delete(instance.Status.Attributes, podName)
-	// If the pod was deemed safeToBootstrap, this state has to be reassessed
-	if instance.Status.SafeToBootstrap == podName {
-		instance.Status.SafeToBootstrap = ""
-	}
 }
 
 // clearOldPodsAttributesOnScaleDown removes known information from old pods


### PR DESCRIPTION
Galera CR exposes status.safeToBootstrap but this field is never updated. This change removes the unused field.