### PR TITLE
Simplify condition check in kuttl tests

### DIFF
--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -15,38 +15,8 @@ spec:
   storageRequest: 500M
 status:
   conditions:
-  - message: Setup complete
-    reason: Ready
-    status: "True"
+  - status: "True"
     type: Ready
-  - message: Deployment completed
-    reason: Ready
-    status: "True"
-    type: DeploymentReady
-  - message: Exposing service completed
-    reason: Ready
-    status: "True"
-    type: ExposeServiceReady
-  - message: MariaDB dbinit completed
-    reason: Ready
-    status: "True"
-    type: MariaDBInitialized
-  - message: RoleBinding created
-    reason: Ready
-    status: "True"
-    type: RoleBindingReady
-  - message: Role created
-    reason: Ready
-    status: "True"
-    type: RoleReady
-  - message: ServiceAccount created
-    reason: Ready
-    status: "True"
-    type: ServiceAccountReady
-  - message: Service config create completed
-    reason: Ready
-    status: "True"
-    type: ServiceConfigReady
 ---
 apiVersion: v1
 kind: Pod

--- a/tests/kuttl/tests/galera_deploy/01-assert.yaml
+++ b/tests/kuttl/tests/galera_deploy/01-assert.yaml
@@ -17,6 +17,10 @@ spec:
   storageRequest: 500M
   containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   replicas: 3
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/tests/kuttl/tests/galera_deploy/02-assert.yaml
+++ b/tests/kuttl/tests/galera_deploy/02-assert.yaml
@@ -11,6 +11,10 @@ metadata:
   name: openstack
 spec:
   replicas: 1
+status:
+  conditions:
+  - status: "True"
+    type: Ready
 ---
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
Currently we assert every single field in conditions but this requires updating the expected values in case any message is updated in the underlying dependencies.

Because we have env test which is more suitable to assert conditions, this simplifies the assertions in kuttl tests.

This also updates the tests for Galera CR to ensure the overall Ready condition is updated successfully.