### PR TITLE
Temporarily use 1 Galera replica as a workaround

### DIFF
--- a/config/samples/mariadb_v1beta1_galera_3_replicas.yaml
+++ b/config/samples/mariadb_v1beta1_galera_3_replicas.yaml
@@ -7,5 +7,4 @@ spec:
   storageClass: local-storage
   storageRequest: 500M
   containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
-  # FIXME: dropping replicas to 1 as a workaround while we investigate MariaDB 10.5 replication issues
-  replicas: 1
+  replicas: 3


### PR DESCRIPTION
We're doing this while we investigate a MariaDB 10.5 issue with replication