### PR TITLE
Watch RBAC resources to trigger reconcile

### DIFF
--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -660,5 +660,8 @@ func (r *GaleraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Endpoints{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -387,5 +387,8 @@ func (r *MariaDBReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Pod{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Complete(r)
 }


### PR DESCRIPTION
This ensures the controller watches service account, role, and role bindings to reconcile these resources in case any change is made.