### PR TITLE
Configure renovate to pin k8s and controller-runtime for dev preview

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,8 +26,15 @@
     },
     {
       "groupName": "k8s.io",
-      "matchPackagePatterns": ["^k8s.io", "^sigs.k8s.io"],
-      "allowedVersions": "< 1.0.0",
+      "matchPackagePatterns": ["^k8s.io"],
+      "excludePackagePatterns": ["^k8s.io/kube-openapi"],
+      "allowedVersions": "< 0.27.0",
+      "enabled": true
+    },
+    {
+      "groupName": "sigs.k8s.io/controller-runtime",
+      "matchPackagePatterns": ["^sigs.k8s.io/controller-runtime"],
+      "allowedVersions": "< 0.15.0",
       "enabled": true
     },
     {


### PR DESCRIPTION
This pins k8s and controller runtime to be in sync with lib-common and configure renovate to keep the pin
