### PR TITLE
Use lib-common for pvc

### DIFF
--- a/pkg/mariadb/pvc.go
+++ b/pkg/mariadb/pvc.go
@@ -3,6 +3,7 @@ package mariadb
 import (
 	databasev1beta1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -13,6 +14,17 @@ func Pvc(db *databasev1beta1.MariaDB) *corev1.PersistentVolumeClaim {
 			Name:      "mariadb-" + db.Name,
 			Namespace: db.Namespace,
 			Labels:    GetLabels(db.Name),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(db.Spec.StorageRequest),
+				},
+			},
+			StorageClassName: &db.Spec.StorageClass,
 		},
 	}
 	return pv


### PR DESCRIPTION
Looks like mariadb pvcs are not cleaned up when the mariadb instances are deleted. Let's use the lib-common methods to CreateOrPatch pvc. Whether to retain the pv when pvc are deleted would be decided by the StorageClass.