### PR TITLE
switch to structured logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,6 @@ func main() {
 	if err = (&controllers.GaleraReconciler{
 		Client:  mgr.GetClient(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("Galera"),
 		Scheme:  mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Galera")
@@ -114,7 +113,6 @@ func main() {
 	if err = (&controllers.MariaDBReconciler{
 		Client:  mgr.GetClient(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("MariaDB"),
 		Scheme:  mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MariaDB")
@@ -123,7 +121,6 @@ func main() {
 	if err = (&controllers.MariaDBDatabaseReconciler{
 		Client:  mgr.GetClient(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("MariaDBDatabase"),
 		Scheme:  mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MariaDBDatabase")


### PR DESCRIPTION
This automatically adds additional fields like reconcile_id etc.. from the controller context.

before :

`2023-05-18T01:53:14+03:00 INFO  controllers.KeystoneAPI Reconciled Service init successfully`

after:

`2023-10-19T10:38:14+03:00       INFO    Controllers.galera      StatefulSet openstack-cell1-galera - updated    {"controller": "galera", "controllerGroup": "mariadb.openstack.org", "controllerKind": "Galera", "Galera": {"name":"openstack-cell1","namespace":"openstack"}, "namespace": "openstack", "name": "openstack-cell1", "reconcileID": "ceb646eb-6400-460a-a49a-a75b8c821abc"}
`

*by using per reconcile function respective logger objects, the intention is to lay the ground for parallel reconciliation in future and avoid race conditions as ctx objects are reconcile run specific.


