### PR TITLE
galera: support mariabackup SST method

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -78,6 +78,13 @@ spec:
               secret:
                 description: Name of the secret to look for password keys
                 type: string
+              sst:
+                default: rsync
+                description: Snapshot State Transfer method to use for full node synchronization
+                enum:
+                - rsync
+                - mariabackup
+                type: string
               storageClass:
                 description: Storage class to host the mariadb databases
                 type: string

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -80,7 +80,20 @@ type GaleraSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// Log Galera pod's output to disk
 	LogToDisk bool `json:"logToDisk"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=rsync
+	// +kubebuilder:validation:Enum=rsync;mariabackup
+	// Snapshot State Transfer method to use for full node synchronization
+	SST GaleraSST `json:"sst"`
 }
+
+// Supported SST type
+type GaleraSST string
+
+const (
+	RSync       GaleraSST = "rsync"
+	MariaBackup GaleraSST = "mariabackup"
+)
 
 // GaleraAttributes holds startup information for a Galera host
 type GaleraAttributes struct {

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -78,6 +78,13 @@ spec:
               secret:
                 description: Name of the secret to look for password keys
                 type: string
+              sst:
+                default: rsync
+                description: Snapshot State Transfer method to use for full node synchronization
+                enum:
+                - rsync
+                - mariabackup
+                type: string
               storageClass:
                 description: Storage class to host the mariadb databases
                 type: string

--- a/config/samples/mariadb_v1beta1_galera_sst.yaml
+++ b/config/samples/mariadb_v1beta1_galera_sst.yaml
@@ -1,0 +1,10 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+  storageRequest: 500M
+  replicas: 3
+  sst: mariabackup

--- a/pkg/mariadb/volumes.go
+++ b/pkg/mariadb/volumes.go
@@ -37,6 +37,13 @@ func getGaleraVolumes(g *mariadbv1.Galera) []corev1.Volume {
 		}
 	}
 
+	if g.Spec.SST == mariadbv1.MariaBackup {
+		configTemplates = append(configTemplates, corev1.KeyToPath{
+			Key:  "galera_sst_mariabackup.cnf.in",
+			Path: "galera_sst_mariabackup.cnf.in",
+		})
+	}
+
 	volumes := []corev1.Volume{
 		{
 			Name: "secrets",

--- a/templates/galera/bin/mysql_probe.sh
+++ b/templates/galera/bin/mysql_probe.sh
@@ -2,7 +2,7 @@
 set -u
 
 # This secret is mounted by k8s and always up to date
-read -s -u 3 3< /var/lib/secrets/dbpassword MYSQL_PWD || true
+read -s -u 3 3< <(cat /var/lib/secrets/dbpassword; echo) MYSQL_PWD
 export MYSQL_PWD
 
 PROBE_USER=root

--- a/templates/galera/config/config.json
+++ b/templates/galera/config/config.json
@@ -29,6 +29,13 @@
             "optional": true
         },
         {
+            "source": "/var/lib/config-data/generated/galera_sst_mariabackup.cnf",
+            "dest": "/etc/my.cnf.d/galera_mariabackup.cnf",
+            "owner": "root",
+            "perm": "0644",
+            "optional": true
+        },
+        {
             "source": "/var/lib/operator-scripts",
             "dest": "/usr/local/bin",
             "owner": "root",

--- a/templates/galera/config/galera_sst_mariabackup.cnf.in
+++ b/templates/galera/config/galera_sst_mariabackup.cnf.in
@@ -1,0 +1,3 @@
+[mysqld]
+wsrep_sst_method = mariabackup
+wsrep_sst_auth = root:{ MARIABACKUP_PASSWORD }

--- a/templates/galera/config/init_config.json
+++ b/templates/galera/config/init_config.json
@@ -1,0 +1,10 @@
+{
+    "command": "/usr/bin/true",
+    "permissions": [
+        {
+            "path": "/var/lib/mysql",
+            "owner": "mysql:mysql",
+            "recurse": "true"
+        }
+    ]
+}

--- a/templates/galera/config/my.cnf.in
+++ b/templates/galera/config/my.cnf.in
@@ -1,0 +1,4 @@
+[client]
+user=root
+host=localhost
+password={ DB_ROOT_PASSWORD }


### PR DESCRIPTION
Make the SST method configurable in the galera custom resource, and allow both rsync and mariabackup methods.
Mariabackup requires a database user's credentials to operate, so reuse the root db user for the time being.

The ability to inject passwords in template galera config files has been implemented. We benefit from that to generate the usual .my.cnf config file for mysql CLI running in the galera container.