### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,69 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/mariadb-operator.clusterserviceversion.yaml"
-
-echo "Creating mariadb operator bundle"
+echo "Creating manila operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/mariadb-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "controller:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/api/v1beta1/mariadb_types.go
+++ b/api/v1beta1/mariadb_types.go
@@ -114,7 +114,7 @@ func (instance MariaDB) RbacResourceName() string {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Keystone defaults with them
 	mariaDBDefaults := MariaDBDefaults{
-		ContainerImageURL: util.GetEnvVar("MARIADB_IMAGE_URL_DEFAULT", MariaDBContainerImage),
+		ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_MARIADB_IMAGE_URL_DEFAULT", MariaDBContainerImage),
 	}
 
 	SetupMariaDBDefaults(mariaDBDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,5 +11,5 @@ spec:
       containers:
       - name: manager
         env:
-        - name: MARIADB_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_MARIADB_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified

--- a/config/manifests/bases/mariadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/mariadb-operator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
     operators.operatorframework.io/operator-type: non-standalone
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: mariadb-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/tests/kuttl/common/assert_sample_deployment.yaml
+++ b/tests/kuttl/common/assert_sample_deployment.yaml
@@ -10,7 +10,6 @@ kind: Galera
 metadata:
   name: openstack
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   replicas: 3
   secret: osp-secret
   storageRequest: 500M
@@ -70,7 +69,6 @@ spec:
         - /usr/bin/dumb-init
         - --
         - /usr/local/bin/kolla_start
-        image: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
         name: galera
         ports:
         - containerPort: 3306
@@ -124,3 +122,29 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: openstack-config-data
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      # when using image digests the containerImage URLs are SHA's so we verify them with a script
+      tupleTemplate='{{ range (index .spec.template.spec.containers 1).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
+      imageTuples=$(oc get -n openstack-operators deployment mariadb-operator-controller-manager -o go-template="$tupleTemplate")
+      # format of imageTuple is: RELATED_IMAGE_MARIADB_<service>#<image URL with SHA> separated by newlines
+      for ITEM in $(echo $imageTuples); do
+        # it is an image
+        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+          NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_MARIADB_\([^_]*\)_.*|\1|')
+          IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
+          template='{{ (index .spec.template.spec.containers 0).image }}'
+          case $NAME in
+            IMAGE)
+              STATEFUL_SET_IMG=$(oc get -n $NAMESPACE statefulset openstack-galera -o go-template="$template")
+              ;;
+          esac
+          if [ "$STATEFUL_SET_IMG" != "$IMG_FROM_ENV" ]; then
+            echo "$NAME image does not equal $VALUE"
+            exit 1
+          fi
+        fi
+      done

--- a/tests/kuttl/tests/mariadb_deploy/01-assert.yaml
+++ b/tests/kuttl/tests/mariadb_deploy/01-assert.yaml
@@ -10,7 +10,6 @@ kind: MariaDB
 metadata:
   name: openstack
 spec:
-  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
   secret: osp-secret
   storageRequest: 500M
 status:
@@ -60,8 +59,7 @@ metadata:
   name: mariadb-openstack
 spec:
   containers:
-  - image: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
-    imagePullPolicy: IfNotPresent
+  - imagePullPolicy: IfNotPresent
     name: mariadb
     resources: {}
   restartPolicy: Always


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)