### PR TITLE
required infra annotations for OCP 4.14+

### DIFF
--- a/config/manifests/bases/mariadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/mariadb-operator.clusterserviceversion.yaml
@@ -4,9 +4,10 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    features.operators.openshift.io/disconnected: "true"
     operatorframework.io/suggested-namespace: openstack
-    operators.operatorframework.io/operator-type: non-standalone
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.operatorframework.io/operator-type: non-standalone
   name: mariadb-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Update to use new 'features.operators.openshift.io' annotations format for disconnected support

Jira: [OSP-30201](https://issues.redhat.com//browse/OSP-30201)