### PR TITLE
fix bundle validate: Add Galera to config/samples

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -2,4 +2,5 @@
 resources:
 - mariadb_v1beta1_mariadb.yaml
 - mariadb_v1beta1_mariadbdatabase.yaml
+- mariadb_v1beta1_galera.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples


### PR DESCRIPTION
Resolves:

WARN[0000] Warning: Value mariadb.openstack.org/v1beta1, Kind=Galera: provided API should have an example annotation