### PR TITLE
when generating metadata.name, use dashes instead of underscores

### DIFF
--- a/api/v1beta1/mariadbdatabase_funcs.go
+++ b/api/v1beta1/mariadbdatabase_funcs.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -171,7 +172,7 @@ func (d *Database) CreateOrPatchDBByName(
 	if account == nil {
 		account = &MariaDBAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      d.databaseUser,
+				Name:      strings.Replace(d.databaseUser, "_", "-", -1),
 				Namespace: d.namespace,
 				Labels: map[string]string{
 					"mariaDBDatabaseName": d.name,
@@ -366,7 +367,7 @@ func (d *Database) getDBWithName(
 	err = h.GetClient().Get(
 		ctx,
 		types.NamespacedName{
-			Name:      username,
+			Name:      strings.Replace(username, "_", "-", -1),
 			Namespace: namespace,
 		},
 		account)


### PR DESCRIPTION
The Database{} facade that is now used to generate a MariaDBDatabase as well as a MariaDBAccount is currently generating a metadata name for the MariaDBAccount based on the username.  As we do in other places, if this username has underscores in it as is common, swap them out with dashes.