### PR TITLE
FIPS support

### DIFF
--- a/templates/galera/config/galera_tls.cnf.in
+++ b/templates/galera/config/galera_tls.cnf.in
@@ -4,7 +4,7 @@ ssl-cert = /etc/pki/tls/certs/galera.crt
 ssl-key = /etc/pki/tls/private/galera.key
 ssl-ca = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ssl-cipher = !SSLv2:kEECDH:kRSA:kEDH:kPSK:+3DES:!aNULL:!eNULL:!MD5:!EXP:!RC4:!SEED:!IDEA:!DES:!SSLv3:!TLSv1
-wsrep_provider_options = gcache.recover=no;gmcast.listen_addr=tcp://{ PODIP }:4567;socket.ssl_key=/etc/pki/tls/private/galera.key;socket.ssl_cert=/etc/pki/tls/certs/galera.crt;socket.ssl_cipher=AES128-SHA256;socket.ssl_ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem;
+wsrep_provider_options = gcache.recover=no;gmcast.listen_addr=tcp://{ PODIP }:4567;socket.ssl_key=/etc/pki/tls/private/galera.key;socket.ssl_cert=/etc/pki/tls/certs/galera.crt;socket.ssl_cipher={ SSL_CIPHER };socket.ssl_ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem;
 
 [sst]
 sockopt = cipher=!SSLv2:kEECDH:kRSA:kEDH:kPSK:+3DES:!aNULL:!eNULL:!MD5:!EXP:!RC4:!SEED:!IDEA:!DES:!SSLv3:!TLSv1


### PR DESCRIPTION
This patch sets the TLS SSL Cipher based on the OCP FIPS mode.

In non FIPS clusters uses AES128-SHA256
And in FIPS clusters uses ECDHE-RSA-AES256-GCM-SHA384

This is the equivalent of what was being done in TripleO [1] [2]

[1]: https://opendev.org/openstack/tripleo-heat-templates/src/commit/500cdbb7deab8034d8a2e2f84cfb2648b7f8c0a4/deployment/database/mysql-pacemaker-puppet.yaml#L107
[2]: https://opendev.org/openstack/tripleo-heat-templates/src/commit/500cdbb7deab8034d8a2e2f84cfb2648b7f8c0a4/environments/fips.yaml#L12

Jira: #[OSPRH-4669](https://issues.redhat.com//browse/OSPRH-4669)