### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,5 +59,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -254,7 +254,7 @@ func clearPodAttributes(instance *mariadbv1.Galera, podName string) {
 
 // clearOldPodsAttributesOnScaleDown removes known information from old pods
 // that no longer exist after a scale down of the galera CR
-func clearOldPodsAttributesOnScaleDown(helper *helper.Helper, instance *mariadbv1.Galera, ctx context.Context) {
+func clearOldPodsAttributesOnScaleDown(ctx context.Context, instance *mariadbv1.Galera) {
 	log := GetLog(ctx, "galera")
 	replicas := int(*instance.Spec.Replicas)
 
@@ -606,7 +606,7 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 
 	// Ensure status is cleaned up in case of scale down
 	if *statefulset.Spec.Replicas < statefulset.Status.Replicas {
-		clearOldPodsAttributesOnScaleDown(helper, instance, ctx)
+		clearOldPodsAttributesOnScaleDown(ctx, instance)
 	}
 
 	// Ensure that all the ongoing galera start actions are still running
@@ -806,7 +806,7 @@ func (r *GaleraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // used by both MariaDBDatabaseReconciler and MariaDBAccountReconciler
 // this will later return only Galera objects, so as a lookup it's part of the galera controller
 
-func GetDatabaseObject(clientObj client.Client, ctx context.Context, name string, namespace string) (*databasev1beta1.Galera, error) {
+func GetDatabaseObject(ctx context.Context, clientObj client.Client, name string, namespace string) (*databasev1beta1.Galera, error) {
 	dbGalera := &databasev1beta1.Galera{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -819,9 +819,9 @@ func GetDatabaseObject(clientObj client.Client, ctx context.Context, name string
 	err := clientObj.Get(ctx, objectKey, dbGalera)
 	if err != nil {
 		return nil, err
-	} else {
-		return dbGalera, err
 	}
+
+	return dbGalera, err
 }
 
 // findObjectsForSrc - returns a reconcile request if the object is referenced by a Galera CR
@@ -834,7 +834,7 @@ func (r *GaleraReconciler) findObjectsForSrc(ctx context.Context, src client.Obj
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.List(context.TODO(), crList, listOps)
+		err := r.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}

--- a/controllers/mariadbaccount_controller.go
+++ b/controllers/mariadbaccount_controller.go
@@ -119,17 +119,17 @@ func (r *MariaDBAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, nil
 	}
 
-	if instance.DeletionTimestamp.IsZero() {
-		return r.reconcileCreate(ctx, req, log, helper, instance)
+	if instance.DeletionTimestamp.IsZero() { //revive:disable:indent-error-flow
+		return r.reconcileCreate(ctx, log, helper, instance)
 	} else {
-		return r.reconcileDelete(ctx, req, log, helper, instance)
+		return r.reconcileDelete(ctx, log, helper, instance)
 	}
 
 }
 
 // reconcileDelete - run reconcile for case where delete timestamp is zero
 func (r *MariaDBAccountReconciler) reconcileCreate(
-	ctx context.Context, req ctrl.Request, log logr.Logger,
+	ctx context.Context, log logr.Logger,
 	helper *helper.Helper, instance *databasev1beta1.MariaDBAccount) (result ctrl.Result, _err error) {
 
 	// this is following from how the MariaDBDatabase CRD works.
@@ -257,7 +257,7 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 	// account create
 
 	// ensure secret is present before running a job
-	_, secret_result, err := secret.VerifySecret(
+	_, secretResult, err := secret.VerifySecret(
 		ctx,
 		types.NamespacedName{Name: instance.Spec.Secret, Namespace: instance.Namespace},
 		[]string{"DatabasePassword"},
@@ -272,7 +272,7 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 			condition.SeverityInfo,
 			databasev1beta1.MariaDBAccountSecretNotReadyMessage, err))
 
-		return secret_result, err
+		return secretResult, err
 	}
 
 	log.Info(fmt.Sprintf("Running account create '%s' MariaDBDatabase '%s'", instance.Name, mariadbDatabaseName))
@@ -321,7 +321,7 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 
 // reconcileDelete - run reconcile for case where delete timestamp is non zero
 func (r *MariaDBAccountReconciler) reconcileDelete(
-	ctx context.Context, req ctrl.Request, log logr.Logger,
+	ctx context.Context, log logr.Logger,
 	helper *helper.Helper, instance *databasev1beta1.MariaDBAccount) (result ctrl.Result, _err error) {
 
 	// this is following from how the MariaDBDatabase CRD works.
@@ -402,19 +402,7 @@ func (r *MariaDBAccountReconciler) reconcileDelete(
 	if err != nil {
 
 		log.Error(err, "Error getting database object")
-
-		if k8s_errors.IsNotFound(err) {
-			// remove finalizer from the MariaDBDatabase instance
-			if controllerutil.RemoveFinalizer(mariadbDatabase, fmt.Sprintf("%s-%s", helper.GetFinalizer(), instance.Name)) {
-				err = r.Update(ctx, mariadbDatabase)
-			}
-
-			// remove local finalizer
-			controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
-
-			// galera DB does not exist, so return
-			return ctrl.Result{}, nil
-		} else {
+		if !k8s_errors.IsNotFound(err) {
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				databasev1beta1.MariaDBServerReadyCondition,
 				condition.ErrorReason,
@@ -424,6 +412,20 @@ func (r *MariaDBAccountReconciler) reconcileDelete(
 
 			return ctrl.Result{}, err
 		}
+
+		// remove finalizer from the MariaDBDatabase instance
+		if controllerutil.RemoveFinalizer(mariadbDatabase, fmt.Sprintf("%s-%s", helper.GetFinalizer(), instance.Name)) {
+			if err = r.Update(ctx, mariadbDatabase); err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		}
+
+		// remove local finalizer
+		controllerutil.RemoveFinalizer(instance, helper.GetFinalizer())
+
+		// galera DB does not exist, so return
+		return ctrl.Result{}, nil
+
 	}
 
 	var dbInstance, dbAdminSecret, dbContainerImage, serviceAccountName string
@@ -502,7 +504,7 @@ func (r *MariaDBAccountReconciler) reconcileDelete(
 func (r *MariaDBAccountReconciler) getDatabaseObject(ctx context.Context, mariaDBDatabase *databasev1beta1.MariaDBDatabase, instance *databasev1beta1.MariaDBAccount) (*databasev1beta1.Galera, error) {
 	dbName := mariaDBDatabase.ObjectMeta.Labels["dbName"]
 	return GetDatabaseObject(
-		r.Client, ctx,
+		ctx, r.Client,
 		dbName,
 		instance.Namespace,
 	)

--- a/controllers/mariadbdatabase_controller.go
+++ b/controllers/mariadbdatabase_controller.go
@@ -247,7 +247,7 @@ func (r *MariaDBDatabaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // getDatabaseObject - returns a Galera object
 func (r *MariaDBDatabaseReconciler) getDatabaseObject(ctx context.Context, instance *databasev1beta1.MariaDBDatabase) (*databasev1beta1.Galera, error) {
 	return GetDatabaseObject(
-		r.Client, ctx,
+		ctx, r.Client,
 		instance.ObjectMeta.Labels["dbName"],
 		instance.Namespace,
 	)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/pkg/mariadb/service.go
+++ b/pkg/mariadb/service.go
@@ -15,14 +15,14 @@ func ServiceForAdoption(db metav1.Object, dbType string, adoption *databasev1bet
 
 	if adoptionHost != "" {
 		if adoptionHostIsIP {
-			return externalServiceFromIP(db, adoption)
+			return externalServiceFromIP(db)
 		}
 		return externalServiceFromName(db, adoption)
 	}
-	return internalService(db, dbType, adoption)
+	return internalService(db, dbType)
 }
 
-func internalService(db metav1.Object, dbType string, adoption *databasev1beta1.AdoptionRedirectSpec) *corev1.Service {
+func internalService(db metav1.Object, dbType string) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      db.GetName(),
@@ -39,7 +39,7 @@ func internalService(db metav1.Object, dbType string, adoption *databasev1beta1.
 	return svc
 }
 
-func externalServiceFromIP(db metav1.Object, adoption *databasev1beta1.AdoptionRedirectSpec) *corev1.Service {
+func externalServiceFromIP(db metav1.Object) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      db.GetName(),

--- a/pkg/mariadb/statefulset.go
+++ b/pkg/mariadb/statefulset.go
@@ -56,7 +56,7 @@ func StatefulSet(g *mariadbv1.Galera, configHash string) *appsv1.StatefulSet {
 								},
 							},
 						}},
-						VolumeMounts: getGaleraInitVolumeMounts(g),
+						VolumeMounts: getGaleraInitVolumeMounts(),
 					}},
 					Containers: []corev1.Container{{
 						Image: g.Spec.ContainerImage,

--- a/pkg/mariadb/volumes.go
+++ b/pkg/mariadb/volumes.go
@@ -178,7 +178,7 @@ func getGaleraVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 	return volumeMounts
 }
 
-func getGaleraInitVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
+func getGaleraInitVolumeMounts() []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			MountPath: "/var/lib/mysql",


### PR DESCRIPTION
This needed the following adjustments:
* ignore revive dot-imports rule on ginkgo and gomega as dot import
  there is the recommended practice
* fix a bug that is shown when error flow is indented that when removing
  the finalizer fails that failure is ignored.
* various small style fixes found by the linter
