### PR TITLE
remove now-unused mariadb funcs

### DIFF
--- a/api/v1beta1/mariadbdatabase_types.go
+++ b/api/v1beta1/mariadbdatabase_types.go
@@ -97,8 +97,6 @@ type Database struct {
 	secretObj        *corev1.Secret    // Secret object referenced by MariaDBAccount
 	databaseHostname string            // string hostname of database
 	databaseName     string            // string name used in CREATE DATABASE statement
-	databaseUser     string            // legacy; will go away when operators fully integrate MariaDBAccount
-	secret           string            // legacy; will go away when operators fully integrate MariaDBAccount
 	labels           map[string]string // labels to add to the MariaDBDatabase object
 	name             string            // CR name for the MariaDBDatabase object
 	accountName      string            // CR name for the MariaDBAccount object


### PR DESCRIPTION
every operator is now updated on the newer functions (octavia is still trying to merge), remove all the old functions and old "legacy" codepaths, as a first pass to making this module a little clearer.