### PR TITLE
[pre-commit][kuttl]Fix false positive asserts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,11 @@ repos:
   hooks:
     - id: golangci-lint-full
       args: ["-v"]
+
+- repo: https://github.com/openstack-k8s-operators/openstack-k8s-operators-ci
+  # NOTE(gibi): we cannot automatically track main here
+  # see https://pre-commit.com/#using-the-latest-version-for-a-repository
+  rev: e30d72fcbced0ab8a7b6d23be1dee129e2a7b849
+  hooks:
+    - id: kuttl-single-test-assert
+      args: ["tests/kuttl"]

--- a/tests/kuttl/tests/database_create/03-assert.yaml
+++ b/tests/kuttl/tests/database_create/03-assert.yaml
@@ -3,27 +3,18 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      set -euxo pipefail
       oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@character_set_database;" kuttldb_latin1' | grep -o -w latin1
       oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@collation_database;" kuttldb_latin1' | grep -o -w latin1_general_ci
-
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   - script: |
+      set -euxo pipefail
       oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@character_set_database;" kuttldb_utf8' | grep -o -w utf8
       oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@collation_database;" kuttldb_utf8' | grep -o -w utf8_general_ci
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   # for legacy secret non-present, test that a mariadb username was *not* made
   - script: |
+      set -euxo pipefail
       ${MARIADB_KUTTL_DIR:-tests/kuttl/tests}/../common/scripts/check_db_account.sh openstack-galera-0 kuttldb_utf8 kuttldb_utf_8 12345678 --reverse
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   # for legacy secret present, test that a mariadb username was made
   - script: |
+      set -euxo pipefail
       ${MARIADB_KUTTL_DIR:-tests/kuttl/tests}/../common/scripts/check_db_account.sh openstack-galera-0 kuttldb_legacy_secret kuttldb_legacy_secret dbsecret1

--- a/tests/kuttl/tests/galera_create_user_require_tls/02-assert.yaml
+++ b/tests/kuttl/tests/galera_create_user_require_tls/02-assert.yaml
@@ -2,12 +2,10 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      set -euxo pipefail
       # ensure db users are configured to TLS restriction
       oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`kuttldb\`@\`%\`;"' | grep 'REQUIRE SSL'
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
   - script: |
+      set -euxo pipefail
       # ensure db users are configured to TLS restriction
       oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`anotheruser\`@\`%\`;"' | grep 'REQUIRE SSL'


### PR DESCRIPTION
Kuttl only runs the last TestAssert in an assert file and silently
ignores the rest. So this patch combines the TestAsserts into a single
one with multiple commands listed.
Also to further secure against false positives `set -euxo pipefail` is
added to the scripts as well.
Also added a new pre-commit check to avoid this in the future.