### PR TITLE
Add required infrastructure annotations

### DIFF
--- a/config/manifests/bases/mariadb-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/mariadb-operator.clusterserviceversion.yaml
@@ -6,8 +6,11 @@ metadata:
     capabilities: Basic Install
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
-    operatorframework.io/suggested-namespace: openstack
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operators.operatorframework.io/operator-type: non-standalone
   name: mariadb-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
Also removes deprecated operators.openshift.io/infrastructure-features annotation.

Also, drops the suggested namespace annotation which is not needed.

Jira: https://issues.redhat.com/browse/OSPRH-7939