### PR TITLE
Ability to configure a Galera CR to log on disk

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -64,6 +64,9 @@ spec:
                 description: When TLS is configured, only allow connections to the
                   DB over TLS
                 type: boolean
+              logToDisk:
+                description: Log Galera pod's output to disk
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -81,6 +81,9 @@ type GaleraSpecCore struct {
 	// +kubebuilder:validation:Optional
 	// When TLS is configured, only allow connections to the DB over TLS
 	DisableNonTLSListeners bool `json:"disableNonTLSListeners,omitempty"`
+	// +kubebuilder:validation:Optional
+	// Log Galera pod's output to disk
+	LogToDisk bool `json:"logToDisk"`
 }
 
 // GaleraAttributes holds startup information for a Galera host

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -64,6 +64,9 @@ spec:
                 description: When TLS is configured, only allow connections to the
                   DB over TLS
                 type: boolean
+              logToDisk:
+                description: Log Galera pod's output to disk
+                type: boolean
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -802,7 +802,9 @@ func (r *GaleraReconciler) generateConfigMaps(
 	envVars *map[string]env.Setter,
 ) error {
 	log := GetLog(ctx, "galera")
-	templateParameters := make(map[string]interface{})
+	templateParameters := map[string]interface{}{
+		"logToDisk": instance.Spec.LogToDisk,
+	}
 	customData := make(map[string]string)
 	customData[mariadbv1.CustomServiceConfigFile] = instance.Spec.CustomServiceConfig
 

--- a/pkg/mariadb/volumes.go
+++ b/pkg/mariadb/volumes.go
@@ -142,6 +142,7 @@ func getGaleraVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 		{
 			MountPath: "/var/lib/mysql",
 			Name:      "mysql-db",
+			SubPath:   "mysql",
 		}, {
 			MountPath: "/var/lib/config-data/default",
 			ReadOnly:  true,
@@ -162,6 +163,10 @@ func getGaleraVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 			ReadOnly:  true,
 			Name:      "kolla-config",
 		},
+	}
+
+	if g.Spec.LogToDisk {
+		volumeMounts = append(volumeMounts, getGaleraLogMount())
 	}
 
 	if g.Spec.TLS.Enabled() {
@@ -182,11 +187,12 @@ func getGaleraVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 	return volumeMounts
 }
 
-func getGaleraInitVolumeMounts() []corev1.VolumeMount {
+func getGaleraInitVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			MountPath: "/var/lib/mysql",
 			Name:      "mysql-db",
+			SubPath:   "mysql",
 		}, {
 			MountPath: "/var/lib/config-data/default",
 			ReadOnly:  true,
@@ -209,5 +215,17 @@ func getGaleraInitVolumeMounts() []corev1.VolumeMount {
 		},
 	}
 
+	if g.Spec.LogToDisk {
+		volumeMounts = append(volumeMounts, getGaleraLogMount())
+	}
+
 	return volumeMounts
+}
+
+func getGaleraLogMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		MountPath: "/var/log/mariadb",
+		Name:      "mysql-db",
+		SubPath:   "log",
+	}
 }

--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -3,6 +3,9 @@ set +eux
 
 if [ -e /var/lib/mysql/mysql ]; then
     echo -e "Database already exists. Reuse it."
+    # set up permissions of mounted directories before starting
+    # galera or the sidecar logging container
+    sudo -E kolla_set_configs
 else
     echo -e "Creating new mariadb database."
     # we need the right perm on the persistent directory,

--- a/templates/galera/config/config.json
+++ b/templates/galera/config/config.json
@@ -55,6 +55,11 @@
             "path": "/var/lib/mysql",
             "owner": "mysql:mysql",
             "recurse": "true"
+        },
+        {
+            "path": "/var/log/mariadb",
+            "owner": "mysql:mysql",
+            "recurse": "true"
         }
     ]
 }

--- a/templates/galera/config/galera.cnf.in
+++ b/templates/galera/config/galera.cnf.in
@@ -18,7 +18,9 @@ innodb_flush_log_at_trx_commit = 1
 innodb_locks_unsafe_for_binlog = 1
 innodb_strict_mode = OFF
 key_buffer_size = 16M
-# log-error = /var/log/mariadb/mariadb.log
+{{if .logToDisk}}
+log-error = /var/log/mariadb/mariadb.log
+{{end}}
 max_allowed_packet = 16M
 max_binlog_size = 100M
 max_connections = 4096
@@ -51,7 +53,9 @@ wsrep_slave_threads = 1
 wsrep_sst_method = rsync
 
 [mysqld_safe]
-# log-error = /var/log/mariadb/mariadb.log
+{{if .logToDisk}}
+log-error = /var/log/mariadb/mariadb.log
+{{end}}
 nice = 0
 pid-file = /var/lib/mysql/mariadb.pid
 socket = /var/lib/mysql/mysql.sock

--- a/tests/kuttl/tests/galera_log_to_disk/01-assert.yaml
+++ b/tests/kuttl/tests/galera_log_to_disk/01-assert.yaml
@@ -1,0 +1,122 @@
+#
+# Check for:
+#
+# - 1 MariaDB CR
+# - 1 Pod for MariaDB CR
+#
+
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: openstack
+spec:
+  replicas: 1
+  secret: osp-secret
+  storageRequest: 500M
+status:
+  bootstrapped: true
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Deployment completed
+    reason: Ready
+    status: "True"
+    type: DeploymentReady
+  - message: Exposing service completed
+    reason: Ready
+    status: "True"
+    type: ExposeServiceReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: RoleBinding created
+    reason: Ready
+    status: "True"
+    type: RoleBindingReady
+  - message: Role created
+    reason: Ready
+    status: "True"
+    type: RoleReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
+  - message: Service config create completed
+    reason: Ready
+    status: "True"
+    type: ServiceConfigReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: TLSInputReady
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openstack-galera
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: galera
+      cr: galera-openstack
+      galera/name: openstack
+  serviceName: openstack-galera
+  template:
+    metadata:
+      labels:
+        app: galera
+        cr: galera-openstack
+        galera/name: openstack
+    spec:
+      containers:
+      - command:
+        - /usr/bin/dumb-init
+        - --
+        - /usr/local/bin/kolla_start
+        name: galera
+        ports:
+        - containerPort: 3306
+          name: mysql
+          protocol: TCP
+        - containerPort: 4567
+          name: galera
+          protocol: TCP
+      serviceAccount: galera-openstack
+      serviceAccountName: galera-openstack
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: openstack-galera-0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openstack-galera
+spec:
+  ports:
+  - name: mysql
+    port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app: galera
+    cr: galera-openstack
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: openstack-galera
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openstack-config-data

--- a/tests/kuttl/tests/galera_log_to_disk/01-deploy_galera.yaml
+++ b/tests/kuttl/tests/galera_log_to_disk/01-deploy_galera.yaml
@@ -1,0 +1,9 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+  storageRequest: 500M
+  replicas: 1

--- a/tests/kuttl/tests/galera_log_to_disk/02-assert.yaml
+++ b/tests/kuttl/tests/galera_log_to_disk/02-assert.yaml
@@ -1,0 +1,23 @@
+#
+# Check for the log side car container in the galera pod
+#
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openstack-galera
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: openstack-galera-0
+status:
+   containerStatuses:
+   - name: galera
+     ready: true
+   - name: log
+     ready: true

--- a/tests/kuttl/tests/galera_log_to_disk/02-enable_logs.yaml
+++ b/tests/kuttl/tests/galera_log_to_disk/02-enable_logs.yaml
@@ -1,0 +1,10 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: openstack
+spec:
+  secret: osp-secret
+  storageClass: local-storage
+  storageRequest: 500M
+  replicas: 1
+  logToDisk: true


### PR DESCRIPTION
Add the ability to store galera logs on disk, in addition to logging to stdout.

When used, galera logs on disk, and an additional sidecar container tail the output of the log file on stdout for honouring regular kubectl logs command.

With this change, both the mysql database on disk and the logs use the same PVC, and they each mount a subpath to distinguish database and logs on disk. This way, storage configuration is not impacted, the logs and the database are always collocated, and logs are not stored under /var/log/mysql, so there is no bad interaction with e.g. SST.

By default, logging is not enabled, so there is no operational impact.

Jira: [OSPRH-4983](https://issues.redhat.com//browse/OSPRH-4983)