### PR TITLE
Fix labelSelector for podAntiAffinity rule

### DIFF
--- a/pkg/mariadb/utils.go
+++ b/pkg/mariadb/utils.go
@@ -1,6 +1,7 @@
 package mariadb
 
 import (
+	common "github.com/openstack-k8s-operators/lib-common/modules/common"
 	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,9 +32,10 @@ func LabelSelectors(database metav1.Object, dbType string) map[string]string {
 func StatefulSetLabels(database metav1.Object) map[string]string {
 	name := database.GetName()
 	return labels.GetLabels(database, "galera", map[string]string{
-		"owner": "mariadb-operator",
-		"app":   "galera",
-		"cr":    "galera-" + name,
+		"owner":            "mariadb-operator",
+		"app":              "galera",
+		"cr":               "galera-" + name,
+		common.AppSelector: StatefulSetName(name),
 	})
 }
 


### PR DESCRIPTION
right now the pod template specifies these labels and affinity labelSelector.

~~~
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: galera
        cr: galera-openstack-cell1
        galera/name: openstack-cell1
        galera/namespace: openstack
        galera/uid: a14e79ce-ef87-41eb-9e05-ddbaeccb82af
        owner: mariadb-operator
    spec:
      affinity:
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - podAffinityTerm:
              labelSelector:
                matchExpressions:
                - key: service
                  operator: In
                  values:
                  - openstack-cell1-galera
              topologyKey: kubernetes.io/hostname
            weight: 1
~~~

Which means that the podAntiAffinity would never bump the weight for the galera pods.

This adds a label with the common service selector.

Related: https://issues.redhat.com/browse/OSPRH-8870