### PR TITLE
Allow intermediate replicas to ease operation

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -69,11 +69,9 @@ spec:
               replicas:
                 default: 1
                 description: Size of the galera cluster deployment
-                enum:
-                - 1
-                - 3
                 format: int32
-                minimum: 1
+                maximum: 3
+                minimum: 0
                 type: integer
               secret:
                 description: Name of the secret to look for password keys

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -57,9 +57,9 @@ type GaleraSpecCore struct {
 	// Storage size allocated for the mariadb databases
 	// +kubebuilder:validation:Required
 	StorageRequest string `json:"storageRequest"`
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=3
 	// +kubebuilder:default=1
-	// +kubebuilder:validation:Enum=1;3
 	// Size of the galera cluster deployment
 	Replicas *int32 `json:"replicas"`
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -69,11 +69,9 @@ spec:
               replicas:
                 default: 1
                 description: Size of the galera cluster deployment
-                enum:
-                - 1
-                - 3
                 format: int32
-                minimum: 1
+                maximum: 3
+                minimum: 0
                 type: integer
               secret:
                 description: Name of the secret to look for password keys

--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -819,7 +819,7 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		}
 
 		// Check if we have enough info to bootstrap the cluster now
-		if !found {
+		if !found && int(*instance.Spec.Replicas) > 0 {
 			node, found = findBestCandidate(instance)
 		}
 		if found {


### PR DESCRIPTION
Currently the mariadb operator has webhooks to enforce the galera replica count to be either 1 or 3, which are the two supported deployments on the OpenstackControlPlane.

However there is a need for more flexibility for day two operations, where it can be useful to allow scaling down replicas temporarily to e.g. 2 (for replacement procedure) or even 0 (to temporarily disable database management).

Replace the kubebuilder annotations with minimum and maximum, and let the galera webhook warn about setting replicas to 2 (as it is not advisable to keep that setting for quorum concerns).