### PR TITLE
[18.0-fr1][make]Add force-bump target to bump operator deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,3 +379,13 @@ run-with-webhook: export OPERATOR_TEMPLATES=./templates/
 run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 	/bin/bash hack/configure_local_webhook.sh
 	go run ./main.go -metrics-bind-address ":$(METRICS_PORT)" -health-probe-bind-address ":$(HEALTH_PORT)"
+
+BRANCH=18.0-fr1
+.PHONY: force-bump
+force-bump: ## Force bump operator and lib-common dependencies
+	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|mariadb-operator|^replace' | awk '{print $$1}'); do \
+		go get $$dep@$(BRANCH) ; \
+	done
+	for dep in $$(cat api/go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|mariadb-operator|^replace' | awk '{print $$1}'); do \
+		cd ./api && go get $$dep@$(BRANCH) && cd .. ; \
+	done


### PR DESCRIPTION
The new force-bump target bumps operator and lib-common dependencies of this operator by tracking the same branch from these dependencies.

18.0-fr1 only change:

* resolve the merge conflict in Makefile due to cef6af11 is not in 18.0-fr1
* switched the branch target of force-bump to 18.0-fr1

Related: [OSPRH-8355](https://issues.redhat.com//browse/OSPRH-8355)
(cherry picked from commit fad9c73f332bcb6e8693532a65fa4b9251abb367)