### PR TITLE
Ensure nodeSelector logic is consistent for all operators

### DIFF
--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -64,7 +64,7 @@ type GaleraSpecCore struct {
 	Replicas *int32 `json:"replicas"`
 	// +kubebuilder:validation:Optional
 	// NodeSelector to target subset of worker nodes running this service
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector *map[string]string `json:"nodeSelector,omitempty"`
 	// +kubebuilder:validation:Optional
 	// Customize config using this parameter to change service defaults,
 	// or overwrite rendered information using raw MariaDB config format.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -179,9 +179,13 @@ func (in *GaleraSpecCore) DeepCopyInto(out *GaleraSpecCore) {
 	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
+		*out = new(map[string]string)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make(map[string]string, len(*in))
+			for key, val := range *in {
+				(*out)[key] = val
+			}
 		}
 	}
 	in.TLS.DeepCopyInto(&out.TLS)

--- a/controllers/mariadbaccount_controller.go
+++ b/controllers/mariadbaccount_controller.go
@@ -282,7 +282,7 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 
 	log.Info(fmt.Sprintf("Running account create '%s' MariaDBDatabase '%s'", instance.Name, mariadbDatabaseName))
 
-	jobDef, err := mariadb.CreateDbAccountJob(instance, mariadbDatabase.Spec.Name, dbHostname, dbAdminSecret, dbContainerImage, serviceAccountName)
+	jobDef, err := mariadb.CreateDbAccountJob(instance, mariadbDatabase.Spec.Name, dbHostname, dbAdminSecret, dbContainerImage, serviceAccountName, dbGalera.Spec.NodeSelector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -507,7 +507,7 @@ func (r *MariaDBAccountReconciler) reconcileDelete(
 
 	log.Info(fmt.Sprintf("Running account delete '%s' MariaDBDatabase '%s'", instance.Name, mariadbDatabaseName))
 
-	jobDef, err := mariadb.DeleteDbAccountJob(instance, mariadbDatabase.Spec.Name, dbHostname, dbAdminSecret, dbContainerImage, serviceAccountName)
+	jobDef, err := mariadb.DeleteDbAccountJob(instance, mariadbDatabase.Spec.Name, dbHostname, dbAdminSecret, dbContainerImage, serviceAccountName, dbGalera.Spec.NodeSelector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/mariadbdatabase_controller.go
+++ b/controllers/mariadbdatabase_controller.go
@@ -195,7 +195,7 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	)
 
 	// Define a new Job object (hostname, password, containerImage)
-	jobDef, err := mariadb.DbDatabaseJob(instance, dbHostname, dbSecret, dbContainerImage, serviceAccount, useTLS)
+	jobDef, err := mariadb.DbDatabaseJob(instance, dbHostname, dbSecret, dbContainerImage, serviceAccount, useTLS, dbGalera.Spec.NodeSelector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/mariadb/account.go
+++ b/pkg/mariadb/account.go
@@ -18,7 +18,7 @@ type accountCreateOrDeleteOptions struct {
 	RequireTLS            string
 }
 
-func CreateDbAccountJob(account *databasev1beta1.MariaDBAccount, databaseName string, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string) (*batchv1.Job, error) {
+func CreateDbAccountJob(account *databasev1beta1.MariaDBAccount, databaseName string, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string, nodeSelector *map[string]string) (*batchv1.Job, error) {
 	var tlsStatement string
 	if account.Spec.RequireTLS {
 		tlsStatement = " REQUIRE SSL"
@@ -90,10 +90,14 @@ func CreateDbAccountJob(account *databasev1beta1.MariaDBAccount, databaseName st
 		},
 	}
 
+	if nodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *nodeSelector
+	}
+
 	return job, nil
 }
 
-func DeleteDbAccountJob(account *databasev1beta1.MariaDBAccount, databaseName string, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string) (*batchv1.Job, error) {
+func DeleteDbAccountJob(account *databasev1beta1.MariaDBAccount, databaseName string, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string, nodeSelector *map[string]string) (*batchv1.Job, error) {
 
 	opts := accountCreateOrDeleteOptions{account.Spec.UserName, databaseName, databaseHostName, "root", ""}
 
@@ -138,6 +142,10 @@ func DeleteDbAccountJob(account *databasev1beta1.MariaDBAccount, databaseName st
 				},
 			},
 		},
+	}
+
+	if nodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *nodeSelector
 	}
 
 	return job, nil

--- a/pkg/mariadb/database.go
+++ b/pkg/mariadb/database.go
@@ -20,7 +20,7 @@ type dbCreateOptions struct {
 }
 
 // DbDatabaseJob -
-func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string, useTLS bool) (*batchv1.Job, error) {
+func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string, useTLS bool, nodeSelector *map[string]string) (*batchv1.Job, error) {
 	var tlsStatement string
 	if useTLS {
 		tlsStatement = " REQUIRE SSL"
@@ -115,11 +115,15 @@ func DbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName s
 		},
 	}
 
+	if nodeSelector != nil && len(*nodeSelector) > 0 {
+		job.Spec.Template.Spec.NodeSelector = *nodeSelector
+	}
+
 	return job, nil
 }
 
 // DeleteDbDatabaseJob -
-func DeleteDbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string) (*batchv1.Job, error) {
+func DeleteDbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHostName string, databaseSecret string, containerImage string, serviceAccountName string, nodeSelector *map[string]string) (*batchv1.Job, error) {
 
 	opts := dbCreateOptions{
 		database.Spec.Name,
@@ -204,6 +208,10 @@ func DeleteDbDatabaseJob(database *databasev1beta1.MariaDBDatabase, databaseHost
 				},
 			},
 		},
+	}
+
+	if nodeSelector != nil {
+		job.Spec.Template.Spec.NodeSelector = *nodeSelector
 	}
 
 	return job, nil

--- a/pkg/mariadb/statefulset.go
+++ b/pkg/mariadb/statefulset.go
@@ -78,8 +78,8 @@ func StatefulSet(g *mariadbv1.Galera, configHash string) *appsv1.StatefulSet {
 		},
 		corev1.LabelHostname,
 	)
-	if len(g.Spec.NodeSelector) > 0 {
-		sts.Spec.Template.Spec.NodeSelector = g.Spec.NodeSelector
+	if g.Spec.NodeSelector != nil {
+		sts.Spec.Template.Spec.NodeSelector = *g.Spec.NodeSelector
 	}
 
 	return sts

--- a/tests/kuttl/tests/account_create/01-assert.yaml
+++ b/tests/kuttl/tests/account_create/01-assert.yaml
@@ -13,6 +13,8 @@ spec:
   replicas: 1
   secret: osp-secret
   storageRequest: 500M
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
 status:
   bootstrapped: true
   conditions:
@@ -72,6 +74,8 @@ spec:
         cr: galera-openstack
         galera/name: openstack
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       containers:
       - command:
         - /usr/bin/dumb-init
@@ -96,6 +100,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: openstack-galera-0
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
 ---
 apiVersion: v1
 kind: Service

--- a/tests/kuttl/tests/account_create/01-deploy_galera.yaml
+++ b/tests/kuttl/tests/account_create/01-deploy_galera.yaml
@@ -7,3 +7,5 @@ spec:
   storageClass: local-storage
   storageRequest: 500M
   replicas: 1
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""

--- a/tests/kuttl/tests/account_create/02-assert.yaml
+++ b/tests/kuttl/tests/account_create/02-assert.yaml
@@ -3,5 +3,10 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: kuttldb-accounttest-db-create
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
 status:
   succeeded: 1

--- a/tests/kuttl/tests/account_create/05-assert.yaml
+++ b/tests/kuttl/tests/account_create/05-assert.yaml
@@ -7,3 +7,15 @@ commands:
       ${MARIADB_KUTTL_DIR:-tests/kuttl/tests}/../common/scripts/check_db_account.sh openstack-galera-0 kuttldb_accounttest someuser dbsecret1
       # ensure db users are configured without TLS connection restriction
       oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`someuser\`@\`%\`;"' | grep 'GRANT USAGE' | grep -v 'REQUIRE SSL'
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: someuser-account-create
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+status:
+  succeeded: 1


### PR DESCRIPTION
nodeSelectors are not currently applied consistently across all operators.

Some do not support nodeSelectors at all - will be implemented in this series of pull requests.
Some do not apply them to every pod (jobs/cronjobs esp) - will be resolved in this series of pull requests.
Some do not apply a node selector update correctly, only when not initially set.
Some support nodeSelectors but do not inherit the default nodeSelector from the OpenstackControlPlane CR.

Jira: [OSPRH-10734](https://issues.redhat.com//browse/OSPRH-10734)