### PR TITLE
Do not use MustParse to process PVC size

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250218115938-ae95bdfefded
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250227072032-4046ee8c6a91
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250228124213-cd63da392f97
 	k8s.io/api v0.29.14
 	k8s.io/apimachinery v0.29.14
 	k8s.io/client-go v0.29.14

--- a/api/go.sum
+++ b/api/go.sum
@@ -78,8 +78,8 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250218115938-ae95bdfefded h1:09SyMAXgnohPLQGKuvBeR72nxZWXLXI7309RjmYYBUU=
 github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250218115938-ae95bdfefded/go.mod h1:kkjcOSZ7jkHbVzxJd0nDQzjB+vqafuAMgSf7AnEXydw=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250227072032-4046ee8c6a91 h1:JSWODgJhcD1Q5YEwYZwtdE+ixjsjJq70AxwKgggwi3g=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250227072032-4046ee8c6a91/go.mod h1:rgpcv2tLD+/vudXx/gpIQSTuRpk4GOxHx84xwfvQalM=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250228124213-cd63da392f97 h1:3LC66vrXJzGMV/eCdvImosOEL2Cgc2KFJIm2YhfTG3w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250228124213-cd63da392f97/go.mod h1:rgpcv2tLD+/vudXx/gpIQSTuRpk4GOxHx84xwfvQalM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/api/v1beta1/galera_webhook.go
+++ b/api/v1beta1/galera_webhook.go
@@ -172,6 +172,8 @@ func (r *GaleraSpec) ValidateUpdate(old GaleraSpec, basePath *field.Path, namesp
 func (r *GaleraSpecCore) ValidateUpdate(old GaleraSpecCore, basePath *field.Path, namespace string) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	_, errs := common_webhook.ValidateStorageRequest(basePath, r.StorageRequest, storageRequestProdMin, true)
+	allErrs = append(allErrs, errs...)
 	// When a TopologyRef CR is referenced, fail if a different Namespace is
 	// referenced because is not supported
 	if r.TopologyRef != nil {

--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -740,7 +740,12 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		instance.Status.LastAppliedTopology = nil
 	}
 
-	commonstatefulset := commonstatefulset.NewStatefulSet(mariadb.StatefulSet(instance, hashOfHashes, topology), 5)
+	stsSpec, err := mariadb.StatefulSet(instance, hashOfHashes, topology)
+	// an error is detected while creating the StatefulSet spec
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	commonstatefulset := commonstatefulset.NewStatefulSet(stsSpec, 5)
 	sfres, sferr := commonstatefulset.CreateOrPatch(ctx, helper)
 	if sferr != nil {
 		if k8s_errors.IsNotFound(sferr) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250218115938-ae95bdfefded
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250227072032-4046ee8c6a91
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250228124213-cd63da392f97
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-00010101000000-000000000000
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250218115938-ae95bdfefded h1:09SyMAXgnohPLQGKuvBeR72nxZWXLXI7309RjmYYBUU=
 github.com/openstack-k8s-operators/infra-operator/apis v0.5.1-0.20250218115938-ae95bdfefded/go.mod h1:kkjcOSZ7jkHbVzxJd0nDQzjB+vqafuAMgSf7AnEXydw=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250227072032-4046ee8c6a91 h1:JSWODgJhcD1Q5YEwYZwtdE+ixjsjJq70AxwKgggwi3g=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250227072032-4046ee8c6a91/go.mod h1:rgpcv2tLD+/vudXx/gpIQSTuRpk4GOxHx84xwfvQalM=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250228124213-cd63da392f97 h1:3LC66vrXJzGMV/eCdvImosOEL2Cgc2KFJIm2YhfTG3w=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.5.1-0.20250228124213-cd63da392f97/go.mod h1:rgpcv2tLD+/vudXx/gpIQSTuRpk4GOxHx84xwfvQalM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/mariadb/statefulset.go
+++ b/pkg/mariadb/statefulset.go
@@ -15,7 +15,7 @@ import (
 )
 
 // StatefulSet returns a StatefulSet object for the galera cluster
-func StatefulSet(g *mariadbv1.Galera, configHash string, topology *topologyv1.Topology) *appsv1.StatefulSet {
+func StatefulSet(g *mariadbv1.Galera, configHash string, topology *topologyv1.Topology) (*appsv1.StatefulSet, error) {
 	ls := StatefulSetLabels(g)
 	name := StatefulSetName(g.Name)
 	var replicas *int32
@@ -25,7 +25,10 @@ func StatefulSet(g *mariadbv1.Galera, configHash string, topology *topologyv1.To
 		replicas = g.Spec.Replicas
 	}
 	storage := g.Spec.StorageClass
-	storageRequest := resource.MustParse(g.Spec.StorageRequest)
+	storageRequest, err := resource.ParseQuantity(g.Spec.StorageRequest)
+	if err != nil {
+		return nil, err
+	}
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -87,7 +90,7 @@ func StatefulSet(g *mariadbv1.Galera, configHash string, topology *topologyv1.To
 			corev1.LabelHostname,
 		)
 	}
-	return sts
+	return sts, nil
 }
 
 func getGaleraInitContainers(g *mariadbv1.Galera) []corev1.Container {


### PR DESCRIPTION
The `resource.MustParse` function was previously used by the operator to process the `storageSize` request provided by the top-level CR. However, even though `defer()` and `recover()` can be used to handle the `panic()` generated by that function in case of a wrong user input, that approach doesn't seem to work properly and the operator crashes without any chance to recover. The `ParseQuantity` implementation returns an error instead of `panic()`, and it can be easily caught at the operator level. This change moves away from `MustParse` usage and relies on the `ParseQuantity` mechanism.
`.SpecCore` webhooks are updated to catch `allErrs` in case of a wrong quantity string is detected, and [1] will push an update with the next lib-common bump.
This has been already fixed in Glance and Swift [2][3].

[1] https://github.com/openstack-k8s-operators/lib-common/pull/608
[2] https://github.com/openstack-k8s-operators/glance-operator/pull/364
[3] https://github.com/openstack-k8s-operators/swift-operator/pull/190