### PR TITLE
don't assume any CSVs are installed

### DIFF
--- a/hack/run_with_local_webhook.sh
+++ b/hack/run_with_local_webhook.sh
@@ -167,13 +167,15 @@ else
     # Handle operator deployed by Openstack Initialization resource
     CSV_NAME="$(oc get csv -n openstack-operators -l operators.coreos.com/openstack-operator.openstack-operators -o name)"
 
-    printf \
-    "\n\tNow patching openstack operator CSV to scale down deployment resource.
-    To restore it, use:
-    oc patch "${CSV_NAME}" -n openstack-operators --type=json -p=\"[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 1}]\""
+    if [ -n "${CSV_NAME}" ]; then
+        printf \
+        "\n\tNow patching openstack operator CSV to scale down deployment resource.
+        To restore it, use:
+        oc patch "${CSV_NAME}" -n openstack-operators --type=json -p=\"[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 1}]\""
 
-    oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
-    oc scale --replicas=0 -n openstack-operators deploy/mariadb-operator-controller-manager
+        oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
+        oc scale --replicas=0 -n openstack-operators deploy/mariadb-operator-controller-manager
+    fi
 fi
 
 go run ./main.go -metrics-bind-address ":${METRICS_PORT}" -health-probe-bind-address ":${HEALTH_PORT}"


### PR DESCRIPTION
change ae93738183eb86f950a62c6a77ab added the assumption that a CSV would be installed under
operators.coreos.com/openstack-operator.openstack-operators, but this cannot be assumed.  I run run-with-webhook with no csvs installed at all, so this check as well must only proceed with patch commands if CSV_NAME isn't blank.