### PR TITLE
DNM (yet): Get MYSQL_PWD from cluster query, not env

### DIFF
--- a/controllers/mariadbaccount_controller.go
+++ b/controllers/mariadbaccount_controller.go
@@ -237,14 +237,13 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 		return ctrl.Result{}, err
 	}
 
-	var dbAdminSecret, dbContainerImage, serviceAccountName string
+	var dbContainerImage, serviceAccountName string
 
 	if !dbGalera.Status.Bootstrapped {
 		log.Info("DB bootstrap not complete. Requeue...")
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 
-	dbAdminSecret = dbGalera.Spec.Secret
 	dbContainerImage = dbGalera.Spec.ContainerImage
 	serviceAccountName = dbGalera.RbacResourceName()
 
@@ -282,7 +281,7 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 
 	log.Info(fmt.Sprintf("Running account create '%s' MariaDBDatabase '%s'", instance.Name, mariadbDatabaseName))
 
-	jobDef, err := mariadb.CreateDbAccountJob(instance, mariadbDatabase.Spec.Name, dbHostname, dbAdminSecret, dbContainerImage, serviceAccountName, dbGalera.Spec.NodeSelector)
+	jobDef, err := mariadb.CreateDbAccountJob(dbGalera, instance, mariadbDatabase.Spec.Name, dbHostname, dbContainerImage, serviceAccountName, dbGalera.Spec.NodeSelector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -473,7 +472,7 @@ func (r *MariaDBAccountReconciler) reconcileDelete(
 		}
 	}
 
-	var dbAdminSecret, dbContainerImage, serviceAccountName string
+	var dbContainerImage, serviceAccountName string
 
 	if !dbGalera.Status.Bootstrapped {
 		log.Info("DB bootstrap not complete. Requeue...")
@@ -488,7 +487,6 @@ func (r *MariaDBAccountReconciler) reconcileDelete(
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
-	dbAdminSecret = dbGalera.Spec.Secret
 	dbContainerImage = dbGalera.Spec.ContainerImage
 	serviceAccountName = dbGalera.RbacResourceName()
 
@@ -507,7 +505,7 @@ func (r *MariaDBAccountReconciler) reconcileDelete(
 
 	log.Info(fmt.Sprintf("Running account delete '%s' MariaDBDatabase '%s'", instance.Name, mariadbDatabaseName))
 
-	jobDef, err := mariadb.DeleteDbAccountJob(instance, mariadbDatabase.Spec.Name, dbHostname, dbAdminSecret, dbContainerImage, serviceAccountName, dbGalera.Spec.NodeSelector)
+	jobDef, err := mariadb.DeleteDbAccountJob(dbGalera, instance, mariadbDatabase.Spec.Name, dbHostname, dbContainerImage, serviceAccountName, dbGalera.Spec.NodeSelector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/mariadbdatabase_controller.go
+++ b/controllers/mariadbdatabase_controller.go
@@ -161,7 +161,7 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	//
 	// Non-deletion (normal) flow follows
 	//
-	var dbSecret, dbContainerImage, serviceAccount string
+	var dbContainerImage, serviceAccount string
 	// NOTE(dciabrin) When configured to only allow TLS connections, all clients
 	// accessing this DB must support client connection via TLS.
 	useTLS := dbGalera.Spec.TLS.Enabled() && dbGalera.Spec.DisableNonTLSListeners
@@ -179,7 +179,6 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: time.Second * 10}, nil
 	}
 
-	dbSecret = dbGalera.Spec.Secret
 	dbContainerImage = dbGalera.Spec.ContainerImage
 	serviceAccount = dbGalera.RbacResourceName()
 
@@ -195,7 +194,7 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	)
 
 	// Define a new Job object (hostname, password, containerImage)
-	jobDef, err := mariadb.DbDatabaseJob(instance, dbHostname, dbSecret, dbContainerImage, serviceAccount, useTLS, dbGalera.Spec.NodeSelector)
+	jobDef, err := mariadb.DbDatabaseJob(dbGalera, instance, dbHostname, dbContainerImage, serviceAccount, useTLS, dbGalera.Spec.NodeSelector)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/mariadb/statefulset.go
+++ b/pkg/mariadb/statefulset.go
@@ -104,16 +104,6 @@ func getGaleraInitContainers(g *mariadbv1.Galera) []corev1.Container {
 		}, {
 			Name:  "KOLLA_CONFIG_STRATEGY",
 			Value: "COPY_ALWAYS",
-		}, {
-			Name: "DB_ROOT_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: g.Spec.Secret,
-					},
-					Key: "DbRootPassword",
-				},
-			},
 		}},
 		VolumeMounts: getGaleraInitVolumeMounts(g),
 	}}
@@ -131,16 +121,6 @@ func getGaleraContainers(g *mariadbv1.Galera, configHash string) []corev1.Contai
 		}, {
 			Name:  "KOLLA_CONFIG_STRATEGY",
 			Value: "COPY_ALWAYS",
-		}, {
-			Name: "DB_ROOT_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: g.Spec.Secret,
-					},
-					Key: "DbRootPassword",
-				},
-			},
 		}},
 		Ports: []corev1.ContainerPort{{
 			ContainerPort: 3306,

--- a/pkg/mariadb/volumes.go
+++ b/pkg/mariadb/volumes.go
@@ -39,20 +39,6 @@ func getGaleraVolumes(g *mariadbv1.Galera) []corev1.Volume {
 
 	volumes := []corev1.Volume{
 		{
-			Name: "secrets",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: g.Spec.Secret,
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "DbRootPassword",
-							Path: "dbpassword",
-						},
-					},
-				},
-			},
-		},
-		{
 			Name: "kolla-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -117,6 +103,10 @@ func getGaleraVolumes(g *mariadbv1.Galera) []corev1.Volume {
 							Key:  "mysql_wsrep_notify.sh",
 							Path: "mysql_wsrep_notify.sh",
 						},
+						{
+							Key:  "root_auth.sh",
+							Path: "root_auth.sh",
+						},
 					},
 				},
 			},
@@ -141,6 +131,29 @@ func getGaleraVolumes(g *mariadbv1.Galera) []corev1.Volume {
 	return volumes
 }
 
+func getGaleraRootOnlyVolumes(g *mariadbv1.Galera) []corev1.Volume {
+	volumes := []corev1.Volume{
+		{
+			Name: "operator-scripts",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: g.Name + "-scripts",
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  "root_auth.sh",
+							Path: "root_auth.sh",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return volumes
+}
+
 func getGaleraVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -154,10 +167,6 @@ func getGaleraVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 		}, {
 			MountPath: "/var/lib/config-data/generated",
 			Name:      "config-data-generated",
-		}, {
-			MountPath: "/var/lib/secrets",
-			ReadOnly:  true,
-			Name:      "secrets",
 		}, {
 			MountPath: "/var/lib/operator-scripts",
 			ReadOnly:  true,
@@ -191,6 +200,18 @@ func getGaleraVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 	return volumeMounts
 }
 
+func getGaleraRootOnlyVolumeMounts() []corev1.VolumeMount {
+	volumeMounts := []corev1.VolumeMount{
+		{
+			MountPath: "/var/lib/operator-scripts",
+			ReadOnly:  true,
+			Name:      "operator-scripts",
+		},
+	}
+
+	return volumeMounts
+}
+
 func getGaleraInitVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -204,10 +225,6 @@ func getGaleraInitVolumeMounts(g *mariadbv1.Galera) []corev1.VolumeMount {
 		}, {
 			MountPath: "/var/lib/config-data/generated",
 			Name:      "config-data-generated",
-		}, {
-			MountPath: "/var/lib/secrets",
-			ReadOnly:  true,
-			Name:      "secrets",
 		}, {
 			MountPath: "/var/lib/operator-scripts",
 			ReadOnly:  true,

--- a/templates/account.sh
+++ b/templates/account.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source /var/lib/operator-scripts/root_auth.sh
+
 export DatabasePassword=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 
 mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'localhost' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'%' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};"

--- a/templates/database.sh
+++ b/templates/database.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /var/lib/operator-scripts/root_auth.sh
+
 mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "CREATE DATABASE IF NOT EXISTS {{.DatabaseName}}; ALTER DATABASE {{.DatabaseName}} CHARACTER SET '{{.DefaultCharacterSet}}' COLLATE '{{.DefaultCollation}}';"
 
 if [[ "${DatabasePassword}" != "" ]]; then

--- a/templates/delete_account.sh
+++ b/templates/delete_account.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+source /var/lib/operator-scripts/root_auth.sh
+
 mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "DROP USER IF EXISTS '{{.UserName}}'@'localhost'; DROP USER IF EXISTS '{{.UserName}}'@'%';"

--- a/templates/delete_database.sh
+++ b/templates/delete_database.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /var/lib/operator-scripts/root_auth.sh
+
 mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "DROP DATABASE IF EXISTS {{.DatabaseName}};"
 
 if [[ "${DatabasePassword}" != "" ]]; then

--- a/templates/galera/bin/detect_gcomm_and_start.sh
+++ b/templates/galera/bin/detect_gcomm_and_start.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+source /var/lib/operator-scripts/root_auth.sh
+
 URI_FILE=/var/lib/mysql/gcomm_uri
 
 rm -f /var/lib/mysql/mysql.sock

--- a/templates/galera/bin/detect_last_commit.sh
+++ b/templates/galera/bin/detect_last_commit.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+source /var/lib/operator-scripts/root_auth.sh
+
+
 # Adapted from clusterlab's galera resource agent
 recover_args="--datadir=/var/lib/mysql \
                 --user=mysql \

--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set +eux
 
+source /var/lib/operator-scripts/root_auth.sh
+
 if [ -e /var/lib/mysql/mysql ]; then
     echo -e "Database already exists. Reuse it."
     # set up permissions of mounted directories before starting

--- a/templates/galera/bin/mysql_probe.sh
+++ b/templates/galera/bin/mysql_probe.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 set -u
 
-# This secret is mounted by k8s and always up to date
-read -s -u 3 3< /var/lib/secrets/dbpassword MYSQL_PWD || true
-export MYSQL_PWD
+source /var/lib/operator-scripts/root_auth.sh
+
 
 PROBE_USER=root
 

--- a/templates/galera/bin/mysql_shutdown.sh
+++ b/templates/galera/bin/mysql_shutdown.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /var/lib/operator-scripts/root_auth.sh
+
 # NOTE(dciabrin) we might use downward API to populate those in the future
 PODNAME=$HOSTNAME
 SERVICE=${PODNAME/-galera-[0-9]*/}

--- a/templates/galera/bin/mysql_wsrep_notify.sh
+++ b/templates/galera/bin/mysql_wsrep_notify.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /var/lib/operator-scripts/root_auth.sh
+
 # NOTE(dciabrin) we might use downward API to populate those in the future
 PODNAME=$HOSTNAME
 SERVICE=${PODNAME/-galera-[0-9]*/}

--- a/templates/galera/bin/root_auth.sh
+++ b/templates/galera/bin/root_auth.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set +eux
+
+# Get pod name
+POD_NAME=$(hostname)
+
+# API server config
+APISERVER=https://kubernetes.default.svc
+SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
+NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
+TOKEN=$(cat ${SERVICEACCOUNT}/token)
+CACERT=${SERVICEACCOUNT}/ca.crt
+K8S_API="api/v1"
+MARIADB_API="apis/mariadb.openstack.org/v1beta1"
+
+GALERA_INSTANCE="{{.galeraInstanceName}}"
+
+# note jq is not installed in the galera image, macgyvering w/ python instead
+
+SECRET_NAME=$(curl -s \
+    --cacert ${CACERT} \
+    --header "Content-Type:application/json" \
+    --header "Authorization: Bearer ${TOKEN}" \
+    "${APISERVER}/${MARIADB_API}/namespaces/${NAMESPACE}/galeras/${GALERA_INSTANCE}" \
+    | python3 -c "import json, sys; print(json.load(sys.stdin)['spec']['secret'])")
+
+PASSWORD=$(curl -s \
+    --cacert ${CACERT} \
+    --header "Content-Type:application/json" \
+    --header "Authorization: Bearer ${TOKEN}" \
+    "${APISERVER}/${K8S_API}/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}" \
+    | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['DbRootPassword'])" \
+    | base64 -d)
+
+MYSQL_PWD="${PASSWORD}"
+DB_ROOT_PASSWORD="${PASSWORD}"
+
+export MYSQL_PWD
+export DB_ROOT_PASSWORD

--- a/tests/chainsaw/config.yaml
+++ b/tests/chainsaw/config.yaml
@@ -7,7 +7,7 @@ spec:
     assert: 180s
     delete: 180s
     cleanup: 180s
-    exec: 60s
+    exec: 120s
   execution:
     failFast: true
     parallel: 1

--- a/tests/chainsaw/scripts/connect.sh
+++ b/tests/chainsaw/scripts/connect.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 PID=
 connect() {
     exec 6>&- 7<&-

--- a/tests/chainsaw/scripts/mysql-cli.sh
+++ b/tests/chainsaw/scripts/mysql-cli.sh
@@ -2,5 +2,7 @@
 set -u
 ARGS=$1
 SQL=$2
+ROOT_PW_AUTH="source /var/lib/operator-scripts/root_auth.sh; "
 CMD="mysql -uroot -p\$DB_ROOT_PASSWORD $ARGS \"$SQL\""
-oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c "$CMD"
+
+oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c "${ROOT_PW_AUTH} ${CMD}"

--- a/tests/kuttl/common/scripts/check_db_account.sh
+++ b/tests/kuttl/common/scripts/check_db_account.sh
@@ -17,7 +17,7 @@ if [ "$5" = "--reverse" ];then
     not_found=0
 fi
 
-found_username=$(oc rsh -n ${NAMESPACE} -c galera ${galera} /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select user from mysql.user"' | grep -o -w ${username})
+found_username=$(oc rsh -n ${NAMESPACE} -c galera ${galera} /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select user from mysql.user"' | grep -o -w ${username})
 
 # username was not found, exit
 if [ -z "$found_username" ]; then

--- a/tests/kuttl/tests/account_create/05-assert.yaml
+++ b/tests/kuttl/tests/account_create/05-assert.yaml
@@ -6,7 +6,7 @@ commands:
       set -e
       ${MARIADB_KUTTL_DIR:-tests/kuttl/tests}/../common/scripts/check_db_account.sh openstack-galera-0 kuttldb_accounttest someuser dbsecret1
       # ensure db users are configured without TLS connection restriction
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`someuser\`@\`%\`;"' | grep 'GRANT USAGE' | grep -v 'REQUIRE SSL'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`someuser\`@\`%\`;"' | grep 'GRANT USAGE' | grep -v 'REQUIRE SSL'
 ---
 apiVersion: batch/v1
 kind: Job

--- a/tests/kuttl/tests/database_create/03-assert.yaml
+++ b/tests/kuttl/tests/database_create/03-assert.yaml
@@ -4,12 +4,12 @@ kind: TestAssert
 commands:
   - script: |
       set -euxo pipefail
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@character_set_database;" kuttldb_latin1' | grep -o -w latin1
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@collation_database;" kuttldb_latin1' | grep -o -w latin1_general_ci
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@character_set_database;" kuttldb_latin1' | grep -o -w latin1
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@collation_database;" kuttldb_latin1' | grep -o -w latin1_general_ci
   - script: |
       set -euxo pipefail
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@character_set_database;" kuttldb_utf8' | grep -o -w utf8
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@collation_database;" kuttldb_utf8' | grep -o -w utf8_general_ci
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@character_set_database;" kuttldb_utf8' | grep -o -w utf8
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@collation_database;" kuttldb_utf8' | grep -o -w utf8_general_ci
   # for legacy secret non-present, test that a mariadb username was *not* made
   - script: |
       set -euxo pipefail

--- a/tests/kuttl/tests/galera_cluster_restart/03-assert.yaml
+++ b/tests/kuttl/tests/galera_cluster_restart/03-assert.yaml
@@ -3,8 +3,8 @@ kind: TestAssert
 commands:
   - script: |
       # ensure galera/WSREP traffic uses encryption
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.wsrep_provider_options;"' | grep -o -w 'socket.ssl = YES'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.wsrep_provider_options;"' | grep -o -w 'socket.ssl = YES'
       # ensure mysql/SQL traffic uses encryption
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.ssl_cipher;"' | grep -v '^NULL$'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.ssl_cipher;"' | grep -v '^NULL$'
       # ensure the galera cluster is composed of three nodes
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "show status like \"wsrep_cluster_size\";"' | grep -w 3
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "show status like \"wsrep_cluster_size\";"' | grep -w 3

--- a/tests/kuttl/tests/galera_create_user_require_tls/02-assert.yaml
+++ b/tests/kuttl/tests/galera_create_user_require_tls/02-assert.yaml
@@ -4,8 +4,8 @@ commands:
   - script: |
       set -euxo pipefail
       # ensure db users are configured to TLS restriction
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`kuttldb\`@\`%\`;"' | grep 'REQUIRE SSL'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`kuttldb\`@\`%\`;"' | grep 'REQUIRE SSL'
   - script: |
       set -euxo pipefail
       # ensure db users are configured to TLS restriction
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`anotheruser\`@\`%\`;"' | grep 'REQUIRE SSL'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`anotheruser\`@\`%\`;"' | grep 'REQUIRE SSL'

--- a/tests/kuttl/tests/galera_deploy_external_tls/02-assert.yaml
+++ b/tests/kuttl/tests/galera_deploy_external_tls/02-assert.yaml
@@ -3,6 +3,6 @@ kind: TestAssert
 commands:
   - script: |
       # ensure galera does not encrypt WSREP traffic
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.wsrep_provider_options;"' | grep -o -w 'gmcast.listen_addr = tcp'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.wsrep_provider_options;"' | grep -o -w 'gmcast.listen_addr = tcp'
       # ensure mysql/SQL traffic uses encryption
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.ssl_cipher;"' | grep -v '^NULL$'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.ssl_cipher;"' | grep -v '^NULL$'

--- a/tests/kuttl/tests/galera_deploy_tls/02-assert.yaml
+++ b/tests/kuttl/tests/galera_deploy_tls/02-assert.yaml
@@ -3,6 +3,6 @@ kind: TestAssert
 commands:
   - script: |
       # ensure galera/WSREP traffic uses encryption
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.wsrep_provider_options;"' | grep -o -w 'socket.ssl = YES'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.wsrep_provider_options;"' | grep -o -w 'socket.ssl = YES'
       # ensure mysql/SQL traffic uses encryption
-      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.ssl_cipher;"' | grep -v '^NULL$'
+      oc rsh -n ${NAMESPACE} -c galera openstack-galera-0 /bin/sh -c 'source /var/lib/operator-scripts/root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select @@global.ssl_cipher;"' | grep -v '^NULL$'


### PR DESCRIPTION
In order to suit the use case of the MariaDB root password being changed, we would like to use an approach where a new secret object is created that contains the new password for root, which would replace the previous secret.  This secret object would be specific to just the MariaDB root password and no longer part of osp-secret, and it would ideally be immutable as well, thus the requirement that a new secret is created, replacing a previous one, in order to change the password.

(this architecture would also require the
previous secret be accessible in some way in order to facilitate a root pw change, however that's out of the scope of this particular commit. Additionally, we may seek to use the MariaDBAccount CR as a parent of this root-holding secret, but that's also out of scope here and does not change the fact that a new secret object replaces an old one in order to change the password).

The implication of this architecture is that all JobSpecs created by controllers must no longer include the name of the Galera "secret" inside either any EnvVars or any Volumes, which historically is the case when using SecretKeySelector, because the presence of this (now potentially changing) name would become part of the hash for the Job.  This would mean that upon a change of root secret name all jobs for galera objects
mariadbdatabase, mariadbaccount would go stale, leading to all these scripts being re-run again, even though the mariadb root password has no implication of the job results changing.  There's also no mechanism for an "indirect" form of SecretKeySelector to be named that would move from a parent CR of some kind such as MariaDBAccount, as this goes against the notion of the "downward API".

Additionally, the scripts running inside the Galera containers also need access to an updated root password; the current approach of using a combination of secret volume mounts as well as envvars would imply, IIUC, these containers need to be rebuilt on root PW change.

This can all be replaced by a robust mechanism to retrieve the current MySQL root password directly from the k8s API instead, where all scripts in containers have access to the most recent secret / password at all
times.    The approach here is therefore a POC that retrieves the
password from Galera->Spec->Secret.   Later, when root password
changes are introduced, this secret will be pulled from a status
field instead indicating the corret root password at the current moment
regardless of changes to secret within the spec.