### PR TITLE
Do not update status when reconciler exits due to panic

### DIFF
--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -404,6 +404,11 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/mariadbaccount_controller.go
+++ b/controllers/mariadbaccount_controller.go
@@ -96,6 +96,11 @@ func (r *MariaDBAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/mariadbdatabase_controller.go
+++ b/controllers/mariadbdatabase_controller.go
@@ -86,6 +86,11 @@ func (r *MariaDBDatabaseReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {


### PR DESCRIPTION
Currently we use deferred call to always update the status field when Reconcile call exits, which seems correct for any other error except Reconciler exits due to panic.

This change adds a call to recover fucntion and try to handle panic and log error.

Closes: [OSPRH-16940](https://issues.redhat.com//browse/OSPRH-16940)