### PR TITLE
[trivial-fix] Pass correct variable name in NewHelper

### DIFF
--- a/controllers/mariadbaccount_controller.go
+++ b/controllers/mariadbaccount_controller.go
@@ -76,7 +76,7 @@ func (r *MariaDBAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		r.Client,
 		r.Kclient,
 		r.Scheme,
-		r.Log,
+		log,
 	)
 	if err != nil {
 		return ctrl.Result{}, err


### PR DESCRIPTION
There seems to be a typo in passing logging variable name in NewHelper function call. It should be 'log' instead of 'r.Log'.