### PR TITLE
mariadbaccount system accounts (PR 4 of 6)

### DIFF
--- a/api/bases/mariadb.openstack.org_mariadbaccounts.yaml
+++ b/api/bases/mariadb.openstack.org_mariadbaccounts.yaml
@@ -48,6 +48,12 @@ spec:
           spec:
             description: MariaDBAccountSpec defines the desired state of MariaDBAccount
             properties:
+              accountType:
+                default: User
+                enum:
+                - User
+                - System
+                type: string
               requireTLS:
                 default: false
                 description: Account must use TLS to connect to the database

--- a/api/v1beta1/mariadbaccount_types.go
+++ b/api/v1beta1/mariadbaccount_types.go
@@ -48,7 +48,18 @@ type MariaDBAccountSpec struct {
 	// Account must use TLS to connect to the database
 	// +kubebuilder:default=false
 	RequireTLS bool `json:"requireTLS"`
+
+	// +kubebuilder:validation:Enum=User;System
+	// +kubebuilder:default=User
+	AccountType AccountType `json:"accountType,omitempty"`
 }
+
+type AccountType string
+
+const (
+	User   AccountType = "User"
+	System AccountType = "System"
+)
 
 // MariaDBAccountStatus defines the observed state of MariaDBAccount
 type MariaDBAccountStatus struct {
@@ -84,4 +95,12 @@ type MariaDBAccountList struct {
 
 func init() {
 	SchemeBuilder.Register(&MariaDBAccount{}, &MariaDBAccountList{})
+}
+
+func (mariadbAccount MariaDBAccount) IsSystemAccount() bool {
+	return mariadbAccount.Spec.AccountType == System
+}
+
+func (mariadbAccount MariaDBAccount) IsUserAccount() bool {
+	return mariadbAccount.Spec.AccountType == "" || mariadbAccount.Spec.AccountType == User
 }

--- a/config/crd/bases/mariadb.openstack.org_mariadbaccounts.yaml
+++ b/config/crd/bases/mariadb.openstack.org_mariadbaccounts.yaml
@@ -48,6 +48,12 @@ spec:
           spec:
             description: MariaDBAccountSpec defines the desired state of MariaDBAccount
             properties:
+              accountType:
+                default: User
+                enum:
+                - User
+                - System
+                type: string
               requireTLS:
                 default: false
                 description: Account must use TLS to connect to the database

--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -1058,9 +1058,8 @@ func (r *GaleraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// GetDatabaseObject - returns either a Galera or MariaDB object (and an associated client.Object interface).
+// GetDatabaseObject - returns a Galera object.
 // used by both MariaDBDatabaseReconciler and MariaDBAccountReconciler
-// this will later return only Galera objects, so as a lookup it's part of the galera controller
 func GetDatabaseObject(ctx context.Context, clientObj client.Client, name string, namespace string) (*mariadbv1.Galera, error) {
 	dbGalera := &mariadbv1.Galera{
 		ObjectMeta: metav1.ObjectMeta{

--- a/templates/account.sh
+++ b/templates/account.sh
@@ -4,8 +4,11 @@ MYSQL_REMOTE_HOST={{.DatabaseHostname}} source /var/lib/operator-scripts/mysql_r
 
 export DatabasePassword=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 
-mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'localhost' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'%' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};"
-
+if [ -n "{{.DatabaseName}}" ]; then
+    mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'localhost' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'%' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};"
+else
+    mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "GRANT ALL PRIVILEGES ON *.* TO '{{.UserName}}'@'localhost' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};GRANT ALL PRIVILEGES ON *.* TO '{{.UserName}}'@'%' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};"
+fi
 
 # search for the account.  not using SHOW CREATE USER to avoid displaying
 # password hash

--- a/tests/chainsaw/common/system-account-assert.yaml
+++ b/tests/chainsaw/common/system-account-assert.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  labels:
+    dbName: openstack
+  name: chainsawdb-some-system-db-account
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: MariaDBAccount creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
+  - message: MariaDB / Galera server ready
+    reason: Ready
+    status: "True"
+    type: MariaDBServerReady
+---
+apiVersion: v1
+data:
+  DatabasePassword: ZGJzZWNyZXQx
+kind: Secret
+metadata:
+  name: some-system-db-secret
+  # ensure finalizer was added
+  finalizers:
+  - openstack.org/mariadbaccount
+type: Opaque
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: systemuser-account-create
+spec:
+  template:
+    spec: {}
+status:
+  succeeded: 1

--- a/tests/chainsaw/common/system-account-secret.yaml
+++ b/tests/chainsaw/common/system-account-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  DatabasePassword: ZGJzZWNyZXQx
+kind: Secret
+metadata:
+  name: some-system-db-secret
+type: Opaque

--- a/tests/chainsaw/common/system-account.yaml
+++ b/tests/chainsaw/common/system-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  labels:
+    dbName: openstack
+  name: chainsawdb-some-system-db-account
+spec:
+  userName: systemuser
+  secret: some-system-db-secret
+  accountType: System

--- a/tests/chainsaw/scripts/check_db_account.sh
+++ b/tests/chainsaw/scripts/check_db_account.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -x
+
+galera="$1"
+dbname="$2"
+username="$3"
+password="$4"
+
+
+found=0
+not_found=1
+
+if [ "$5" = "--reverse" ];then
+    # sometimes we want to check that a user does not exist
+    found=1
+    not_found=0
+fi
+
+found_username=$(oc exec -n ${NAMESPACE} -c galera ${galera} -- /bin/sh -c 'source /var/lib/operator-scripts/mysql_root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -Nse "select user from mysql.user"' | grep -o -w ${username})
+
+# username was not found, exit
+if [ -z "$found_username" ]; then
+    exit $not_found
+fi
+
+# username was found.  if we wanted it to be found, then check the login also.
+if [ "$found" = "0" ]; then
+    if [ -n "$dbname" ]; then
+        oc exec -n ${NAMESPACE} -c galera ${galera} -- /bin/sh -c "mysql -u${username} -p${password} -Nse 'select database();' ${dbname}" || exit -1
+    else
+        oc exec -n ${NAMESPACE} -c galera ${galera} -- /bin/sh -c "mysql -u${username} -p${password} -Nse 'select 1'" || exit -1
+    fi
+fi
+
+exit $found

--- a/tests/chainsaw/tests/create-system-account/chainsaw-test.yaml
+++ b/tests/chainsaw/tests/create-system-account/chainsaw-test.yaml
@@ -1,0 +1,67 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: create-system-account
+spec:
+  steps:
+  - name: Deploy 1-node cluster
+    description: Deploy a 1-node cluster for tests
+    bindings:
+    - name: replicas
+      value: 1
+    try:
+    - apply:
+        file: ../../common/galera.yaml
+    - assert:
+        file: ../../common/galera-assert.yaml
+
+  - name: create system account without secret
+    description: system account CR has to wait for a secret to create account in the database
+    # we will delete the account manually
+    skipDelete: true
+    try:
+    - apply:
+        file: ../../common/system-account.yaml
+    - assert:
+        file: system-account-missing-secret-assert.yaml
+
+  - name: add secret and finish system account creation
+    description: make sure the system account is created in the database
+    # we will delete the secret manually
+    skipDelete: true
+    try:
+    - apply:
+        file: ../../common/system-account-secret.yaml
+    - assert:
+        file: ../../common/system-account-assert.yaml
+
+  - name: verify system account in database
+    description: check that system account exists in database with correct permissions
+    try:
+    - script:
+        content: |
+          ../../scripts/check_db_account.sh openstack-galera-0 '' systemuser dbsecret1
+        check:
+          ($error): ~
+    - script:
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c 'source /var/lib/operator-scripts/mysql_root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -e "show grants for \`systemuser\`@\`%\`;"' | grep 'GRANT ALL' | grep -v 'REQUIRE SSL'
+        check:
+          ($error): ~
+
+  - name: drop system account
+    description: delete the MariaDBAccount CR and verify account is removed from database
+    try:
+    - delete:
+        ref:
+          apiVersion: mariadb.openstack.org/v1beta1
+          kind: MariaDBAccount
+          name: chainsawdb-some-system-db-account
+    - script:
+        content: |
+          ../../scripts/check_db_account.sh openstack-galera-0 "" systemuser dbsecret1 --reverse
+        check:
+          ($error): ~
+    finally:
+    - delete:
+        file: ../../common/system-account-secret.yaml

--- a/tests/chainsaw/tests/create-system-account/system-account-missing-secret-assert.yaml
+++ b/tests/chainsaw/tests/create-system-account/system-account-missing-secret-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  labels:
+    dbName: openstack
+  name: chainsawdb-some-system-db-account
+status:
+  conditions:
+  - reason: SecretMissing
+    severity: Warning
+    status: "False"
+    type: Ready
+  - reason: SecretMissing
+    severity: Warning
+    status: "False"
+    type: MariaDBAccountReady
+  - message: MariaDB / Galera server ready
+    reason: Ready
+    status: "True"
+    type: MariaDBServerReady

--- a/tests/chainsaw/tests/system-account-preexisting/chainsaw-test.yaml
+++ b/tests/chainsaw/tests/system-account-preexisting/chainsaw-test.yaml
@@ -1,0 +1,63 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: system-account-preexisting
+spec:
+  steps:
+  - name: Deploy 1-node cluster
+    description: Deploy a 1-node cluster for tests
+    bindings:
+    - name: replicas
+      value: 1
+    try:
+    - apply:
+        file: ../../common/galera.yaml
+    - assert:
+        file: ../../common/galera-assert.yaml
+
+  - name: create user manually with old password
+    description: manually create the systemuser account with a different password than the MariaDBAccount will use
+    try:
+    - script:
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c 'source /var/lib/operator-scripts/mysql_root_auth.sh; mysql -uroot -p${DB_ROOT_PASSWORD} -e "GRANT ALL PRIVILEGES ON *.* TO \`systemuser\`@\`localhost\` IDENTIFIED BY \"oldpassword123\"; GRANT ALL PRIVILEGES ON *.* TO \`systemuser\`@\`%\` IDENTIFIED BY \"oldpassword123\";"'
+        check:
+          ($error): ~
+
+  - name: verify old password works
+    description: verify that the manually created account works with the old password
+    try:
+    - script:
+        content: |
+          ../../scripts/check_db_account.sh openstack-galera-0 '' systemuser oldpassword123
+        check:
+          ($error): ~
+
+  - name: apply secret with new password
+    description: apply the secret with the new password that will be used by MariaDBAccount
+    try:
+    - apply:
+        file: ../../common/system-account-secret.yaml
+
+  - name: apply MariaDBAccount
+    description: apply the MariaDBAccount CR to update the existing account password
+    try:
+    - apply:
+        file: ../../common/system-account.yaml
+    - assert:
+        file: ../../common/system-account-assert.yaml
+
+  - name: verify new password works and old password fails
+    description: verify that the account password was updated to the new password from the secret
+    try:
+    - script:
+        content: |
+          ../../scripts/check_db_account.sh openstack-galera-0 '' systemuser dbsecret1
+        check:
+          ($error): ~
+    - script:
+        content: |
+          # verify old password no longer works
+          ! oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c "mysql -usystemuser -poldpassword123 -Nse 'select 1'"
+        check:
+          ($error): ~


### PR DESCRIPTION
introduce a new class of MariaDBAccount called a "system"
MariaDBAccount, indicated by a new enumerated field AccountType
on the CR.  Such accounts link directly to a Galera instance
and have no dependency on a MariaDBDatabase CR.

The expected targets for "system" accounts will include the
Galera/mysql root username and password, as well as a system
account used by mariadbbackup for SST.

Refactor mariadbaccount_controller to isolate logic used for
acquiring MariaDBDatabase and Galera CRs into separate functions,
and ensure all MariaDBDatabase logic takes place only for "user"
accounts (which would be all current MariaDBAccount CRs).

Also correct an oversight where MariaDBAccount would not unconditionally
apply a finalizer to its Secret object.   This logic now takes place
in addition to an unconditional removal of the finalizer when the
MariaDBAccount object is deleted.

A subsequent change will allow system-level passwords to be changed
in place by applying the secret name to two separate fields
MariaDBAccount/Spec/Secret and MariaDBAccount/Status/Secret.  When
these two names differ it will indicate an in-place password change
should take place.
