### PR TITLE
support in-place secret changes (PR 5 of 6)

### DIFF
--- a/api/bases/mariadb.openstack.org_mariadbaccounts.yaml
+++ b/api/bases/mariadb.openstack.org_mariadbaccounts.yaml
@@ -114,6 +114,14 @@ spec:
                   - type
                   type: object
                 type: array
+              currentSecret:
+                description: |-
+                  the Secret that's currently in use for the account.
+                  keeping a handle to this secret allows us to remove its finalizer
+                  when it's replaced with a new one. It also is useful for storing
+                  the current "root" secret separate from a newly proposed one which is
+                  needed when changing the database root password.
+                type: string
               hash:
                 additionalProperties:
                   type: string

--- a/api/v1beta1/mariadbaccount_types.go
+++ b/api/v1beta1/mariadbaccount_types.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	// AccountCreateHash hash
-	AccountCreateHash = "accountcreate"
+	// AccountCreateOrUpdateHash hash
+	AccountCreateOrUpdateHash = "accountcreateorupdate"
 
 	// AccountDeleteHash hash
 	AccountDeleteHash = "accountdelete"
@@ -63,6 +63,13 @@ const (
 
 // MariaDBAccountStatus defines the observed state of MariaDBAccount
 type MariaDBAccountStatus struct {
+	// the Secret that's currently in use for the account.
+	// keeping a handle to this secret allows us to remove its finalizer
+	// when it's replaced with a new one. It also is useful for storing
+	// the current "root" secret separate from a newly proposed one which is
+	// needed when changing the database root password.
+	CurrentSecret string `json:"currentSecret,omitempty"`
+
 	// Deployment Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 

--- a/config/crd/bases/mariadb.openstack.org_mariadbaccounts.yaml
+++ b/config/crd/bases/mariadb.openstack.org_mariadbaccounts.yaml
@@ -114,6 +114,14 @@ spec:
                   - type
                   type: object
                 type: array
+              currentSecret:
+                description: |-
+                  the Secret that's currently in use for the account.
+                  keeping a handle to this secret allows us to remove its finalizer
+                  when it's replaced with a new one. It also is useful for storing
+                  the current "root" secret separate from a newly proposed one which is
+                  needed when changing the database root password.
+                type: string
               hash:
                 additionalProperties:
                   type: string

--- a/templates/account.sh
+++ b/templates/account.sh
@@ -4,15 +4,35 @@ MYSQL_REMOTE_HOST={{.DatabaseHostname}} source /var/lib/operator-scripts/mysql_r
 
 export DatabasePassword=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 
+MYSQL_CMD="mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306"
+
 if [ -n "{{.DatabaseName}}" ]; then
-    mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'localhost' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};GRANT ALL PRIVILEGES ON {{.DatabaseName}}.* TO '{{.UserName}}'@'%' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};"
+    GRANT_DATABASE="{{.DatabaseName}}"
 else
-    mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "GRANT ALL PRIVILEGES ON *.* TO '{{.UserName}}'@'localhost' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};GRANT ALL PRIVILEGES ON *.* TO '{{.UserName}}'@'%' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};"
+    GRANT_DATABASE="*"
 fi
+
+# going for maximum compatibility here:
+# 1. MySQL 8 no longer allows implicit create user when GRANT is used
+# 2. MariaDB has "CREATE OR REPLACE", but MySQL does not
+# 3. create user with CREATE but then do all password and TLS with ALTER to
+#    support updates
+
+$MYSQL_CMD <<EOF
+CREATE USER IF NOT EXISTS '{{.UserName}}'@'localhost';
+CREATE USER IF NOT EXISTS '{{.UserName}}'@'%';
+
+ALTER USER '{{.UserName}}'@'localhost' IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};
+ALTER USER '{{.UserName}}'@'%'  IDENTIFIED BY '$DatabasePassword'{{.RequireTLS}};
+
+GRANT ALL PRIVILEGES ON ${GRANT_DATABASE}.* TO '{{.UserName}}'@'localhost';
+GRANT ALL PRIVILEGES ON ${GRANT_DATABASE}.* TO '{{.UserName}}'@'%';
+EOF
+
 
 # search for the account.  not using SHOW CREATE USER to avoid displaying
 # password hash
-username=$(mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -NB -e "select user from mysql.user where user='{{.UserName}}' and host='localhost';" )
+username=$($MYSQL_CMD -NB -e "select user from mysql.user where user='{{.UserName}}' and host='localhost';" )
 
 if [[ ${username} != "{{.UserName}}" ]]; then
     exit 1

--- a/tests/chainsaw/common/system-account-secret.yaml
+++ b/tests/chainsaw/common/system-account-secret.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 data:
+  # dbsecret1
   DatabasePassword: ZGJzZWNyZXQx
 kind: Secret
 metadata:

--- a/tests/chainsaw/tests/create-system-account/chainsaw-test.yaml
+++ b/tests/chainsaw/tests/create-system-account/chainsaw-test.yaml
@@ -49,6 +49,20 @@ spec:
         check:
           ($error): ~
 
+  - name: update secret in place
+    description: change the secret to a new one and verify password is updated in database
+    skipDelete: true
+    try:
+    - apply:
+        file: system-account-update-secret.yaml
+    - assert:
+        file: system-account-update-assert.yaml
+    - script:
+        content: |
+          ../../scripts/check_db_account.sh openstack-galera-0 '' systemuser dbsecret2
+        check:
+          ($error): ~
+
   - name: drop system account
     description: delete the MariaDBAccount CR and verify account is removed from database
     try:
@@ -59,9 +73,11 @@ spec:
           name: chainsawdb-some-system-db-account
     - script:
         content: |
-          ../../scripts/check_db_account.sh openstack-galera-0 "" systemuser dbsecret1 --reverse
+          ../../scripts/check_db_account.sh openstack-galera-0 "" systemuser dbsecret2 --reverse
         check:
           ($error): ~
     finally:
     - delete:
         file: ../../common/system-account-secret.yaml
+    - delete:
+        file: system-account-update-secret.yaml

--- a/tests/chainsaw/tests/create-system-account/system-account-update-assert.yaml
+++ b/tests/chainsaw/tests/create-system-account/system-account-update-assert.yaml
@@ -6,7 +6,7 @@ metadata:
     dbName: openstack
   name: chainsawdb-some-system-db-account
 status:
-  currentSecret: some-system-db-secret
+  currentSecret: some-new-system-db-secret
   conditions:
   - message: Setup complete
     reason: Ready
@@ -22,22 +22,18 @@ status:
     type: MariaDBServerReady
 ---
 apiVersion: v1
-data:
-  DatabasePassword: ZGJzZWNyZXQx
 kind: Secret
 metadata:
-  name: some-system-db-secret
-  # ensure finalizer was added
+  name: some-new-system-db-secret
+  # ensure finalizer was added to new secret
   finalizers:
   - openstack.org/mariadbaccount
 type: Opaque
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Secret
 metadata:
-  name: systemuser-account-create-update
-spec:
-  template:
-    spec: {}
-status:
-  succeeded: 1
+  name: some-system-db-secret
+  # ensure finalizer was removed from old secret (field should not exist)
+  (finalizers): null
+type: Opaque

--- a/tests/chainsaw/tests/create-system-account/system-account-update-secret.yaml
+++ b/tests/chainsaw/tests/create-system-account/system-account-update-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  # dbsecret2
+  DatabasePassword: ZGJzZWNyZXQy
+kind: Secret
+metadata:
+  name: some-new-system-db-secret
+type: Opaque
+---
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  labels:
+    dbName: openstack
+  name: chainsawdb-some-system-db-account
+spec:
+  userName: systemuser
+  secret: some-new-system-db-secret
+  accountType: System

--- a/tests/kuttl/tests/account_create/05-assert.yaml
+++ b/tests/kuttl/tests/account_create/05-assert.yaml
@@ -11,7 +11,7 @@ commands:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: someuser-account-create
+  name: someuser-account-create-update
 spec:
   template:
     spec:


### PR DESCRIPTION
The existing mariadb operator in fact already "supports" in-place
change of secret, since if you change Spec.Secret to a new secret
name, that would imply a new job hash, and the account.sh script running
using only GRANT statements would update the password per mariadb.
This already works for flipping the TLS flag on and off too.

So in this patch, we clean this up and add a test to include:

* a new field Status.CurrentSecret, which is used to indicate the
  previous secret from which the finalizer should be removed.  This will
  also be used when we migrate the root password to use MariaDBAccount
  by providing the "current" root password when changing to a new root
  password
* improved messaging in log messages, name of job.   This changes the
  job hash for mariadbaccount which will incur a run on existing environments,
  however the
  job hashes are already changing on existing environments due to the
  change in how the mysql root password is sent, i.e. via volume mounted
  script rather than env var secret
* update account.sh to use modern idiomatic patterns for user create
  /alter, while mariadb is fine with the legacy style of using only
  GRANT statements, MySQL 8 no longer allows this statement to proceed
  without a CREATE USER, so formalize the commands used here to use
  distinct CREATE USER, ALTER USER, GRANT statements and clarify the
  script is good for all create/update user operations.
