### PR TITLE
use system MariaDBAccount for the galera server's root pw (PR 6 of 6)

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -137,8 +137,18 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              rootDatabaseAccount:
+                description: |-
+                  RootDatabaseAccount - name of MariaDBAccount which will be used to
+                  generate root account / password.
+                  this account is generated if not exists, and a name is chosen based
+                  on a naming convention if not present
+                type: string
               secret:
-                description: Name of the secret to look for password keys
+                description: |-
+                  Name of the legacy secret to locate the initial galera root
+                  password
+                  this field will be removed once scripts can adjust to using root_auth.sh
                 type: string
               storageClass:
                 description: Storage class to host the mariadb databases
@@ -177,7 +187,6 @@ spec:
             required:
             - containerImage
             - replicas
-            - secret
             - storageClass
             - storageRequest
             type: object
@@ -296,6 +305,9 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              rootDatabaseSecret:
+                description: name of the Secret that is being used for the root password
+                type: string
               safeToBootstrap:
                 description: Name of the node that can safely bootstrap a cluster
                 type: string

--- a/api/v1beta1/conditions.go
+++ b/api/v1beta1/conditions.go
@@ -54,6 +54,9 @@ const (
 	// ReasonDBServiceNameError - error getting the DB service hostname
 	ReasonDBServiceNameError condition.Reason = "DatabaseServiceNameError"
 
+	// ReasonDBResourceDeleted - the galera resource has been marked for deletion
+	ReasonDBResourceDeleted condition.Reason = "DatabaseResourceDeleted"
+
 	// ReasonDBSync - Database sync in progress
 	ReasonDBSync condition.Reason = "DBSync"
 )
@@ -92,7 +95,11 @@ const (
 
 	MariaDBServerNotBootstrappedMessage = "MariaDB / Galera server not bootstrapped"
 
+	MariaDBServerDeletedMessage = "MariaDB / Galera server has been marked for deletion"
+
 	MariaDBAccountReadyInitMessage = "MariaDBAccount create / drop not started"
+
+	MariaDBSystemAccountReadyMessage = "MariaDBAccount System account '%s' creation complete"
 
 	MariaDBAccountReadyMessage = "MariaDBAccount creation complete"
 

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -51,9 +51,19 @@ type GaleraSpec struct {
 
 // GaleraSpec defines the desired state of Galera
 type GaleraSpecCore struct {
-	// Name of the secret to look for password keys
-	// +kubebuilder:validation:Required
+	// Name of the legacy secret to locate the initial galera root
+	// password
+	// this field will be removed once scripts can adjust to using root_auth.sh
+	// +kubebuilder:validation:Optional
 	Secret string `json:"secret"`
+
+	// RootDatabaseAccount - name of MariaDBAccount which will be used to
+	// generate root account / password.
+	// this account is generated if not exists, and a name is chosen based
+	// on a naming convention if not present
+	// +kubebuilder:validation:Optional
+	RootDatabaseAccount string `json:"rootDatabaseAccount"`
+
 	// Storage class to host the mariadb databases
 	// +kubebuilder:validation:Required
 	StorageClass string `json:"storageClass"`
@@ -113,6 +123,9 @@ type GaleraAttributes struct {
 type GaleraStatus struct {
 	// A map of database node attributes for each pod
 	Attributes map[string]GaleraAttributes `json:"attributes,omitempty"`
+	// name of the Secret that is being used for the root password
+	// +kubebuilder:validation:Optional
+	RootDatabaseSecret string `json:"rootDatabaseSecret"`
 	// Name of the node that can safely bootstrap a cluster
 	SafeToBootstrap string `json:"safeToBootstrap,omitempty"`
 	// Is the galera cluster currently running

--- a/api/v1beta1/mariadbaccount_types.go
+++ b/api/v1beta1/mariadbaccount_types.go
@@ -28,9 +28,6 @@ const (
 	// AccountDeleteHash hash
 	AccountDeleteHash = "accountdelete"
 
-	// DbRootPassword selector for galera root account
-	DbRootPasswordSelector = "DbRootPassword"
-
 	// DatabasePassword selector for MariaDBAccount->Secret
 	DatabasePasswordSelector = "DatabasePassword"
 )

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -137,8 +137,18 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              rootDatabaseAccount:
+                description: |-
+                  RootDatabaseAccount - name of MariaDBAccount which will be used to
+                  generate root account / password.
+                  this account is generated if not exists, and a name is chosen based
+                  on a naming convention if not present
+                type: string
               secret:
-                description: Name of the secret to look for password keys
+                description: |-
+                  Name of the legacy secret to locate the initial galera root
+                  password
+                  this field will be removed once scripts can adjust to using root_auth.sh
                 type: string
               storageClass:
                 description: Storage class to host the mariadb databases
@@ -177,7 +187,6 @@ spec:
             required:
             - containerImage
             - replicas
-            - secret
             - storageClass
             - storageRequest
             type: object
@@ -296,6 +305,9 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              rootDatabaseSecret:
+                description: name of the Secret that is being used for the root password
+                type: string
               safeToBootstrap:
                 description: Name of the node that can safely bootstrap a cluster
                 type: string

--- a/templates/account.sh
+++ b/templates/account.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MYSQL_REMOTE_HOST={{.DatabaseHostname}} source /var/lib/operator-scripts/mysql_root_auth.sh
+MYSQL_REMOTE_HOST="{{.DatabaseHostname}}" source /var/lib/operator-scripts/mysql_root_auth.sh
 
 export DatabasePassword=${DatabasePassword:?"Please specify a DatabasePassword variable."}
 
@@ -29,6 +29,10 @@ GRANT ALL PRIVILEGES ON ${GRANT_DATABASE}.* TO '{{.UserName}}'@'localhost';
 GRANT ALL PRIVILEGES ON ${GRANT_DATABASE}.* TO '{{.UserName}}'@'%';
 EOF
 
+# If we just changed the root password, update MYSQL_CMD to use the new password
+if [ "{{.UserName}}" = "{{.DatabaseAdminUsername}}" ]; then
+    MYSQL_CMD="mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -p${DatabasePassword} -P 3306"
+fi
 
 # search for the account.  not using SHOW CREATE USER to avoid displaying
 # password hash

--- a/templates/database.sh
+++ b/templates/database.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MYSQL_REMOTE_HOST={{.DatabaseHostname}} source /var/lib/operator-scripts/mysql_root_auth.sh
+MYSQL_REMOTE_HOST="{{.DatabaseHostname}}" source /var/lib/operator-scripts/mysql_root_auth.sh
 
 mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "CREATE DATABASE IF NOT EXISTS {{.DatabaseName}}; ALTER DATABASE {{.DatabaseName}} CHARACTER SET '{{.DefaultCharacterSet}}' COLLATE '{{.DefaultCollation}}';"
 

--- a/templates/delete_account.sh
+++ b/templates/delete_account.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-MYSQL_REMOTE_HOST={{.DatabaseHostname}} source /var/lib/operator-scripts/mysql_root_auth.sh
+MYSQL_REMOTE_HOST="{{.DatabaseHostname}}" source /var/lib/operator-scripts/mysql_root_auth.sh
 
 mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "DROP USER IF EXISTS '{{.UserName}}'@'localhost'; DROP USER IF EXISTS '{{.UserName}}'@'%';"

--- a/templates/delete_database.sh
+++ b/templates/delete_database.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MYSQL_REMOTE_HOST={{.DatabaseHostname}} source /var/lib/operator-scripts/mysql_root_auth.sh
+MYSQL_REMOTE_HOST="{{.DatabaseHostname}}" source /var/lib/operator-scripts/mysql_root_auth.sh
 
 mysql -h {{.DatabaseHostname}} -u {{.DatabaseAdminUsername}} -P 3306 -e "DROP DATABASE IF EXISTS {{.DatabaseName}};"
 

--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -1,13 +1,58 @@
 #!/bin/bash
 set +eux
 
-source /var/lib/operator-scripts/mysql_root_auth.sh
+# disable my.cnf caching in mysql_root_auth.sh, so that we definitely
+# use the root password defined in the cluster
+MYSQL_ROOT_AUTH_BYPASS_CHECKS=true source /var/lib/operator-scripts/mysql_root_auth.sh
+
+MARIADB_PIDFILE=/var/lib/mysql/mariadb.pid
+function kolla_update_db_root_pw {
+    # update the root password given a set of mariadb datafiles
+
+    # because galera controller generates a new root password if one was
+    # not sent via pre-existing secret, the root pw has to be updated if
+    # existing datafiles are present, as they will still store the previous
+    # root pw which we by definition don't know what it is
+
+    # ported from kolla_extend_start
+    echo -e "Running with --skip-grant-tables to reset root password"
+    rm -fv ${MARIADB_PIDFILE}
+    mysqld_safe --skip-grant-tables --wsrep-on=OFF --pid-file=${MARIADB_PIDFILE} &
+
+    # Wait for the mariadb server to be "Ready" before running root update commands
+    # NOTE(huikang): the location of mysql's socket file varies depending on the OS distributions.
+    # Querying the cluster status has to be executed after the existence of mysql.sock and mariadb.pid.
+    TIMEOUT=${DB_MAX_TIMEOUT:-60}
+    while [[ ! -S /var/lib/mysql/mysql.sock ]] && \
+          [[ ! -S /var/run/mysqld/mysqld.sock ]] || \
+          [[ ! -f "${MARIADB_PIDFILE}" ]]; do
+        if [[ ${TIMEOUT} -gt 0 ]]; then
+            let TIMEOUT-=1
+            sleep 1
+        else
+            echo -e "Surpassed timeout of ${TIMEOUT} without seeing a pidfile"
+            exit 1
+        fi
+    done
+
+    echo -e "Refreshing root passwords"
+    mysql -u root <<EOF
+FLUSH PRIVILEGES;
+ALTER USER 'root'@'localhost' IDENTIFIED BY '$DB_ROOT_PASSWORD';
+ALTER USER 'root'@'%'  IDENTIFIED BY '$DB_ROOT_PASSWORD';
+FLUSH PRIVILEGES;
+EOF
+    echo -e "shutting down skip-grant mysql instance"
+    mysqladmin -uroot -p"${DB_ROOT_PASSWORD}" shutdown
+}
+
 
 if [ -e /var/lib/mysql/mysql ]; then
     echo -e "Database already exists. Reuse it."
     # set up permissions of mounted directories before starting
     # galera or the sidecar logging container
     sudo -E kolla_set_configs
+    kolla_update_db_root_pw
 else
     echo -e "Creating new mariadb database."
     # we need the right perm on the persistent directory,

--- a/test/chainsaw/common/galera-assert.yaml
+++ b/test/chainsaw/common/galera-assert.yaml
@@ -25,6 +25,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: MariaDBAccount System account 'root' creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/chainsaw/common/galera-no-secret-assert.yaml
+++ b/test/chainsaw/common/galera-no-secret-assert.yaml
@@ -1,21 +1,13 @@
-#
-# Check for:
-#
-# - 1 MariaDB CR
-# - 1 Pod for MariaDB CR
-#
-
 apiVersion: mariadb.openstack.org/v1beta1
 kind: Galera
 metadata:
   name: openstack
 spec:
-  replicas: 1
-  secret: osp-secret
+  replicas: ($replicas)
+  secret: ""
   storageRequest: 500M
-  nodeSelector:
-    node-role.kubernetes.io/worker: ""
 status:
+  rootDatabaseSecret: openstack-mariadb-root-db-secret
   bootstrapped: true
   conditions:
   - message: Setup complete
@@ -64,7 +56,7 @@ kind: StatefulSet
 metadata:
   name: openstack-galera
 spec:
-  replicas: 1
+  replicas: ($replicas)
   selector:
     matchLabels:
       app: galera
@@ -78,8 +70,6 @@ spec:
         cr: galera-openstack
         galera/name: openstack
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""
       containers:
       - command:
         - /usr/bin/dumb-init
@@ -96,17 +86,9 @@ spec:
       serviceAccount: galera-openstack
       serviceAccountName: galera-openstack
 status:
-  availableReplicas: 1
-  readyReplicas: 1
-  replicas: 1
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: openstack-galera-0
-spec:
-  nodeSelector:
-    node-role.kubernetes.io/worker: ""
+  availableReplicas: ($replicas)
+  readyReplicas: ($replicas)
+  replicas: ($replicas)
 ---
 apiVersion: v1
 kind: Service
@@ -121,6 +103,15 @@ spec:
   selector:
     app: galera
     cr: galera-openstack
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openstack
+spec:
+  selector:
+    statefulset.kubernetes.io/pod-name:
+      (starts_with(@, 'openstack-galera-')): true
 ---
 apiVersion: v1
 kind: Endpoints

--- a/test/chainsaw/common/galera-no-secret.yaml
+++ b/test/chainsaw/common/galera-no-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: openstack
+spec:
+  replicas: ($replicas)
+  storageClass: local-storage
+  storageRequest: 500M

--- a/test/chainsaw/tests/generate-root-pw/chainsaw-test.yaml
+++ b/test/chainsaw/tests/generate-root-pw/chainsaw-test.yaml
@@ -1,0 +1,41 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: generate-root-pw
+spec:
+  steps:
+  - name: Deploy 1-node cluster
+    description: Deploy a 1-node galera cluster for root password update test
+    bindings:
+    - name: replicas
+      value: 1
+    try:
+    - apply:
+        file: ../../common/galera-no-secret.yaml
+    - assert:
+        file: ../../common/galera-no-secret-assert.yaml
+
+  - name: Verify root MariaDBAccount is created
+    description: Verify the root MariaDBAccount exists and has Status.CurrentSecret set
+    try:
+    - assert:
+        file: root-account-assert.yaml
+
+  - name: Test root connection with generated password
+    description: Extract password from Galera status and test MySQL connection
+    try:
+    - script:
+        content: |
+          # Get the secret name from Galera status
+          SECRET_NAME=$(oc get galera openstack -n ${NAMESPACE} -o jsonpath='{.status.rootDatabaseSecret}')
+          echo "Root secret name: $SECRET_NAME"
+
+          # Extract the password from the secret (base64 decode)
+          ROOT_PASSWORD=$(oc get secret $SECRET_NAME -n ${NAMESPACE} -o jsonpath='{.data.DatabasePassword}' | base64 -d)
+          echo "Extracted password (length: ${#ROOT_PASSWORD})"
+
+          # Test MySQL connection with the extracted password
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c "
+            mysql -uroot -p'$ROOT_PASSWORD' -e 'SELECT 1' > /dev/null
+            echo 'Successfully connected to MySQL with generated root password'
+          "

--- a/test/chainsaw/tests/generate-root-pw/root-account-assert.yaml
+++ b/test/chainsaw/tests/generate-root-pw/root-account-assert.yaml
@@ -1,0 +1,16 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  name: openstack-mariadb-root
+spec:
+  userName: root
+  secret: openstack-mariadb-root-db-secret
+  accountType: System
+status:
+  currentSecret: openstack-mariadb-root-db-secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-mariadb-root-db-secret
+type: Opaque

--- a/test/chainsaw/tests/update-root-pw/chainsaw-test.yaml
+++ b/test/chainsaw/tests/update-root-pw/chainsaw-test.yaml
@@ -1,0 +1,93 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: update-root-pw
+spec:
+  steps:
+  - name: Deploy 3-node cluster
+    description: Deploy a 3-node galera cluster for root password update test
+    bindings:
+    - name: replicas
+      value: 3
+    try:
+    - apply:
+        file: ../../common/galera.yaml
+    - assert:
+        file: ../../common/galera-assert.yaml
+
+  - name: Verify root MariaDBAccount is created
+    description: Verify the root MariaDBAccount exists and has Status.CurrentSecret set
+    try:
+    - assert:
+        file: root-account-initial-assert.yaml
+
+  - name: Verify initial setup
+    description: Verify the cluster is running with initial root password
+    try:
+    - script:
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c '
+            source /var/lib/operator-scripts/mysql_root_auth.sh
+            if [ "$MYSQL_PWD" = "newrootpassword123" ]; then
+              echo "ERROR: password == 'newrootpassword123', should not have changed yet"
+              exit 1
+            fi
+            echo "PASS: password != 'newrootpassword123' (current: $MYSQL_PWD)"
+            mysql -e "SELECT 1" > /dev/null
+            echo "Initial root password works"
+          '
+
+  - name: Create new root password secret
+    description: Create a new secret with updated root password
+    skipDelete: true
+    try:
+    - apply:
+        file: new-root-secret.yaml
+
+  - name: Update root MariaDBAccount with new secret
+    description: Apply the new secret to the root MariaDBAccount spec
+    skipDelete: true
+    try:
+    - apply:
+        file: root-account-updated.yaml
+    - assert:
+        file: root-account-assert.yaml
+
+  - name: Verify Galera status updated
+    description: Wait for Galera status.rootDatabaseSecret to be updated
+    try:
+    - assert:
+        file: galera-status-assert.yaml
+
+  - name: Verify login with new password on all nodes
+    description: Log into all galera nodes with new root password
+    try:
+    - script:
+        content: |
+          for pod in openstack-galera-0 openstack-galera-1 openstack-galera-2; do
+            echo "Testing login on $pod..."
+            oc exec -n ${NAMESPACE} -c galera $pod -- /bin/sh -c '
+              # Clear the cached credentials to force using new password
+              rm -f $HOME/.my.cnf
+              source /var/lib/operator-scripts/mysql_root_auth.sh
+              if [ "$MYSQL_PWD" != "newrootpassword123" ]; then
+                echo "ERROR: password != 'newrootpassword123' (actual: $MYSQL_PWD)"
+                exit 1
+              fi
+              echo "PASS: password == 'newrootpassword123'"
+              mysql -e "SELECT 1" > /dev/null
+              echo "New root password works on $(hostname)"
+            '
+          done
+          echo "All nodes verified successfully"
+
+  - name: Verify new password persists
+    description: Verify the new password still works after cache refresh
+    try:
+    - script:
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c '
+            source /var/lib/operator-scripts/mysql_root_auth.sh
+            mysql -e "SHOW DATABASES" > /dev/null
+            echo "New password persists and works correctly"
+          '

--- a/test/chainsaw/tests/update-root-pw/galera-status-assert.yaml
+++ b/test/chainsaw/tests/update-root-pw/galera-status-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: openstack
+status:
+  # Verify that rootDatabaseSecret has been updated to the new secret
+  rootDatabaseSecret: new-root-secret
+  bootstrapped: true

--- a/test/chainsaw/tests/update-root-pw/new-root-secret.yaml
+++ b/test/chainsaw/tests/update-root-pw/new-root-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: new-root-secret
+type: Opaque
+data:
+  # "newrootpassword123" base64 encoded
+  DatabasePassword: bmV3cm9vdHBhc3N3b3JkMTIz

--- a/test/chainsaw/tests/update-root-pw/root-account-assert.yaml
+++ b/test/chainsaw/tests/update-root-pw/root-account-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  name: openstack-mariadb-root
+spec:
+  userName: root
+  secret: new-root-secret
+  accountType: System
+status:
+  # Verify that the CurrentSecret field has been updated to the new secret
+  currentSecret: new-root-secret

--- a/test/chainsaw/tests/update-root-pw/root-account-initial-assert.yaml
+++ b/test/chainsaw/tests/update-root-pw/root-account-initial-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  name: openstack-mariadb-root
+spec:
+  userName: root
+  secret: openstack-mariadb-root-db-secret
+  accountType: System
+status:
+  currentSecret: openstack-mariadb-root-db-secret

--- a/test/chainsaw/tests/update-root-pw/root-account-updated.yaml
+++ b/test/chainsaw/tests/update-root-pw/root-account-updated.yaml
@@ -1,0 +1,8 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  name: openstack-mariadb-root
+spec:
+  userName: root
+  secret: new-root-secret
+  accountType: System

--- a/test/kuttl/common/assert_sample_deployment.yaml
+++ b/test/kuttl/common/assert_sample_deployment.yaml
@@ -32,6 +32,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: MariaDBAccount System account 'root' creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/database_create/01-assert.yaml
+++ b/test/kuttl/tests/database_create/01-assert.yaml
@@ -32,6 +32,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: MariaDBAccount System account 'root' creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/galera_deploy_external_tls/01-assert.yaml
+++ b/test/kuttl/tests/galera_deploy_external_tls/01-assert.yaml
@@ -27,6 +27,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: MariaDBAccount System account 'root' creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/kuttl/tests/galera_log_to_disk/01-assert.yaml
+++ b/test/kuttl/tests/galera_log_to_disk/01-assert.yaml
@@ -32,6 +32,10 @@ status:
     reason: Ready
     status: "True"
     type: InputReady
+  - message: MariaDBAccount System account 'root' creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
   - message: RoleBinding created
     reason: Ready
     status: "True"


### PR DESCRIPTION
This commit ties together the previous ones to create a new
MariaDBAccount when a Galera instance is created, and then to
use the password from that account/secret in the mariadb
bootstrap/maintenance scripts.

Galera gets bootstrapped with this secret, then the mariadbaccount
controller, who is waiting for galera to be available to set up this
new "root" account, wakes up when galera is running, and changes
the root password to itself, establishing the initial job hash
for the mariadbaccount.

As we now have a mariadbaccount linked to the outermost lifecycle
of a galera instance, some hardening of the deletion process has been
added to clarify that mariadbaccount will run deletion jobs only if
Galera is not marked for deletion.  If galera is marked for deletion,
then we have to assume the service/pods are gone and no more drops can
take place, even if the Galera CR is still present (chainsaw
conveniently adds its own finalizer to Galera when running, preventing
it from being fully deleted, which exposed this issue).
