### PR TITLE
[OSPRH-19099] Use unified Kustomize patches; drop deprecated fields

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,19 +7,19 @@ resources:
 - bases/mariadb.openstack.org_mariadbaccounts.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_galeras.yaml
-#- patches/webhook_in_mariadbdatabases.yaml
-#- patches/webhook_in_mariadbaccounts.yaml
+#- path: patches/webhook_in_galeras.yaml
+#- path: patches/webhook_in_mariadbdatabases.yaml
+#- path: patches/webhook_in_mariadbaccounts.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_galeras.yaml
-#- patches/cainjection_in_mariadbdatabases.yaml
-#- patches/cainjection_in_mariadbaccounts.yaml
+#- path: patches/cainjection_in_galeras.yaml
+#- path: patches/cainjection_in_mariadbdatabases.yaml
+#- path: patches/cainjection_in_mariadbaccounts.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,10 +9,13 @@ namespace: mariadb-operator-system
 namePrefix: mariadb-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+#labels:
+#- includeSelectors: true
+#  includeTemplates: true
+#  pairs:
+#    someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -24,27 +27,27 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+#- path: manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # Injects our custom images (ENV variable settings)
-- manager_default_images.yaml
+- path: manager_default_images.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.
 # These patches remove the unnecessary "cert" volume and its manager container volumeMount.
-#patchesJson6902:
+#patches:
 #- target:
 #    group: apps
 #    version: v1

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - bases/config.yaml
-patchesJson6902:
+patches:
 - path: patches/basic.config.yaml
   target:
     group: scorecard.operatorframework.io
@@ -13,4 +13,4 @@ patchesJson6902:
     version: v1alpha3
     kind: Configuration
     name: config
-#+kubebuilder:scaffold:patchesJson6902
+#+kubebuilder:scaffold:patches


### PR DESCRIPTION
Summary:
- Replace deprecated Kustomize fields with the unified patches format.
- Switch bases to resources in config/default.

Changes:
- config/default/kustomization.yaml:
  - bases -> resources
  - patchesStrategicMerge -> patches; entries converted to - path: ...
- config/crd/kustomization.yaml:
  - patchesStrategicMerge -> patches; entries converted to - path: ...
- config/scorecard/kustomization.yaml:
  - patchesJson6902 -> patches; JSON 6902 ops preserved under path with target
  - update scaffold marker to #+kubebuilder:scaffold:patches
- config/manifests/kustomization.yaml:
  - comment example updated to use #patches:

Validation:
- kustomize build passes for config/default, config/crd, config/scorecard, and config/manifests.

Motivation:
- patchesStrategicMerge and patchesJson6902 are deprecated in Kustomize; using patches avoids subtle generation differences and aligns with other operators.

References:
- Jira: https://issues.redhat.com/browse/OSPRH-19099
- Upstream inspiration: https://github.com/openstack-k8s-operators/keystone-operator/pull/610

Co-authored-by: GPT-5 (AI Assistant) <ai@cursor.sh>