### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -142,7 +142,7 @@ func buildGcommURI(instance *mariadbv1.Galera) string {
 	basename := instance.Name + "-galera"
 	res := []string{}
 
-	for i := 0; i < replicas; i++ {
+	for i := range replicas {
 		// Generate Gcomm with subdomains for TLS validation
 		res = append(res, basename+"-"+strconv.Itoa(i)+"."+basename+"."+instance.Namespace+".svc")
 	}
@@ -943,7 +943,7 @@ func (r *GaleraReconciler) generateConfigMaps(
 	envVars *map[string]env.Setter,
 ) error {
 	log := GetLog(ctx, "galera")
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"logToDisk": instance.Spec.LogToDisk,
 	}
 	customData := make(map[string]string)

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -34,13 +34,13 @@ const (
 	interval = timeout / 100
 )
 
-func CreateGaleraConfig(namespace string, spec map[string]interface{}) client.Object {
+func CreateGaleraConfig(namespace string, spec map[string]any) client.Object {
 	name := uuid.New().String()
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "mariadb.openstack.org/v1beta1",
 		"kind":       "Galera",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name,
 			"namespace": namespace,
 		},
@@ -50,8 +50,8 @@ func CreateGaleraConfig(namespace string, spec map[string]interface{}) client.Ob
 	return th.CreateUnstructured(raw)
 }
 
-func GetDefaultGaleraSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultGaleraSpec() map[string]any {
+	return map[string]any{
 		"replicas":       1,
 		"logToDisk":      false,
 		"secret":         "osp-secret",

--- a/tests/functional/galera_webhook_test.go
+++ b/tests/functional/galera_webhook_test.go
@@ -46,10 +46,10 @@ var _ = Describe("Galera webhook", func() {
 	When("a Galera gets created with a name longer then 46 chars", func() {
 		It("gets blocked by the webhook and fail", func() {
 
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "mariadb.openstack.org/v1beta1",
 				"kind":       "Galera",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      "foo-1234567890-1234567890-1234567890-1234567890",
 					"namespace": namespace,
 				},


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>