### PR TITLE
[OSPRH-20357] Improve consistency of condition severity usage

### DIFF
--- a/controllers/galera_controller.go
+++ b/controllers/galera_controller.go
@@ -578,10 +578,12 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		time.Duration(5)*time.Second)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
+			// Since the OpenStack secret should have been manually created by the user and referenced in the spec,
+			// we treat this as a warning because it means that the service will not be able to start.
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				condition.InputReadyWaitingMessage))
 			return res, fmt.Errorf("%w: %s", ErrOpenStackSecretNotFound, instance.Spec.Secret)
 		}
@@ -610,10 +612,12 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		)
 		if err != nil {
 			if k8s_errors.IsNotFound(err) {
+				// Since the CA bundle secret should have been manually created by the user and provided in the spec,
+				// we treat this as a warning because it means that the service will not be able to start.
 				instance.Status.Conditions.Set(condition.FalseCondition(
 					condition.TLSInputReadyCondition,
-					condition.RequestedReason,
-					condition.SeverityInfo,
+					condition.ErrorReason,
+					condition.SeverityWarning,
 					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}

--- a/controllers/galerabackup_controller.go
+++ b/controllers/galerabackup_controller.go
@@ -235,10 +235,11 @@ func (r *GaleraBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Wait for a Galera object to exist before creating any object (cronjob, PVs...)
+			// Since the Galera object should already exist, we treat this as a warning.
 			instance.Status.Conditions.MarkFalse(
 				mariadbv1.MariaDBResourceExistsCondition,
 				mariadbv1.ReasonResourceNotFound,
-				condition.SeverityInfo,
+				condition.SeverityWarning,
 				mariadbv1.MariaDBResourceInitMessage,
 			)
 			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
@@ -316,8 +317,8 @@ func (r *GaleraBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			helper.GetLogger().Error(err, "CreateOrPatch failed", "pod", backupCronJob.Name)
 			instance.Status.Conditions.MarkFalse(
 				mariadbv1.CronjobReadyCondition,
-				condition.ReadyReason,
-				condition.SeverityInfo,
+				condition.ErrorReason,
+				condition.SeverityWarning,
 				mariadbv1.CronjobReadyErrorMessage,
 				err,
 			)

--- a/controllers/mariadbaccount_controller.go
+++ b/controllers/mariadbaccount_controller.go
@@ -160,11 +160,12 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 	if err != nil && k8s_errors.IsNotFound(err) {
 		// for the create case, need to wait for the MariaDBDatabase to exists before we can continue;
 		// requeue
+		// Since the MariaDBDatabase object should already exist, we treat this as a warning.
 
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			databasev1beta1.MariaDBDatabaseReadyCondition,
 			databasev1beta1.ReasonDBNotFound,
-			condition.SeverityInfo,
+			condition.SeverityWarning,
 			databasev1beta1.MariaDBDatabaseReadyInitMessage))
 
 		log.Info(fmt.Sprintf(
@@ -275,11 +276,12 @@ func (r *MariaDBAccountReconciler) reconcileCreate(
 		time.Duration(30)*time.Second,
 	)
 	if (err != nil || secretResult != ctrl.Result{}) {
-
+		// Since the account secret should have been manually created by the user and referenced in the spec,
+		// we treat this as a warning because it means that the service will not be able to start.
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			databasev1beta1.MariaDBAccountReadyCondition,
 			secret.ReasonSecretMissing,
-			condition.SeverityInfo,
+			condition.SeverityWarning,
 			databasev1beta1.MariaDBAccountSecretNotReadyMessage, err))
 
 		return secretResult, err

--- a/tests/chainsaw/tests/account/account-missing-secret-assert.yaml
+++ b/tests/chainsaw/tests/account/account-missing-secret-assert.yaml
@@ -9,12 +9,12 @@ status:
   conditions:
     # message: 'MariaDBAccount secret is missing or incomplete: Secret $NAMESPACE/some-db-secret not found'
   - reason: SecretMissing
-    severity: Info
+    severity: Warning
     status: "False"
     type: Ready
     # message: 'MariaDBAccount secret is missing or incomplete: Secret $NAMESPACE/some-db-secret not found'
   - reason: SecretMissing
-    severity: Info
+    severity: Warning
     status: "False"
     type: MariaDBAccountReady
   - message: MariaDBDatabase ready

--- a/tests/kuttl/tests/account_create/03-assert.yaml
+++ b/tests/kuttl/tests/account_create/03-assert.yaml
@@ -9,12 +9,12 @@ status:
   conditions:
     # message: 'MariaDBAccount secret is missing or incomplete: Secret $NAMESPACE/some-db-secret not found'
   - reason: SecretMissing
-    severity: Info
+    severity: Warning
     status: "False"
     type: Ready
     # message: 'MariaDBAccount secret is missing or incomplete: Secret $NAMESPACE/some-db-secret not found'
   - reason: SecretMissing
-    severity: Info
+    severity: Warning
     status: "False"
     type: MariaDBAccountReady
   - message: MariaDBDatabase ready


### PR DESCRIPTION
Use consistent condition severity across repeated patterns found in our operators, and otherwise use an appropriate severity for conditions unique to each operator.

Jira: https://issues.redhat.com/browse/OSPRH-20357

Co-authored-by: Claude (Anthropic) [claude@anthropic.com](mailto:claude@anthropic.com)