### PR TITLE
Use DbRootPassword in mysql_root_auth.sh until new password logic lands

### DIFF
--- a/templates/galera/bin/mysql_root_auth.sh
+++ b/templates/galera/bin/mysql_root_auth.sh
@@ -91,7 +91,7 @@ PASSWORD=$(curl -s \
     --header "Content-Type:application/json" \
     --header "Authorization: Bearer ${TOKEN}" \
     "${APISERVER}/${K8S_API}/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}" \
-    | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['DatabasePassword'])" \
+    | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['DbRootPassword'])" \
     | base64 -d)
 
 


### PR DESCRIPTION
In 3527102d103ccf7dcf515325ea2cd9, we accidentally added the new mysql_root_auth.sh root PW script to be using the "DatabasePassword" key in osp-secret, which is incorrect; Galera controller uses DbRootPassword from osp-secret, and it's important to keep this behavior the same until we merge the MariaDBAccount change