### PR TITLE
OSPRH-27668: Reference root MariaDBAccount in Galera->Status

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -142,7 +142,9 @@ spec:
                   RootDatabaseAccount - name of MariaDBAccount which will be used to
                   generate root account / password.
                   this account is generated if not exists, and a name is chosen based
-                  on a naming convention if not present
+                  on a naming convention if not present.
+                  See Galera->Status->RootDatabaseAccount for the actual name in use
+                  regardless of whether this field is set
                 type: string
               secret:
                 description: |-
@@ -305,6 +307,11 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              rootDatabaseAccount:
+                description: |-
+                  RootDatabaseAccount - name of MariaDBAccount being used to maintain
+                  the RootDatabaseSecret.
+                type: string
               rootDatabaseSecret:
                 description: name of the Secret that is being used for the root password
                 type: string

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -60,7 +60,9 @@ type GaleraSpecCore struct {
 	// RootDatabaseAccount - name of MariaDBAccount which will be used to
 	// generate root account / password.
 	// this account is generated if not exists, and a name is chosen based
-	// on a naming convention if not present
+	// on a naming convention if not present.
+	// See Galera->Status->RootDatabaseAccount for the actual name in use
+	// regardless of whether this field is set
 	// +kubebuilder:validation:Optional
 	RootDatabaseAccount string `json:"rootDatabaseAccount"`
 
@@ -123,6 +125,10 @@ type GaleraAttributes struct {
 type GaleraStatus struct {
 	// A map of database node attributes for each pod
 	Attributes map[string]GaleraAttributes `json:"attributes,omitempty"`
+	// RootDatabaseAccount - name of MariaDBAccount being used to maintain
+	// the RootDatabaseSecret.
+	// +kubebuilder:validation:Optional
+	RootDatabaseAccount string `json:"rootDatabaseAccount"`
 	// name of the Secret that is being used for the root password
 	// +kubebuilder:validation:Optional
 	RootDatabaseSecret string `json:"rootDatabaseSecret"`

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -142,7 +142,9 @@ spec:
                   RootDatabaseAccount - name of MariaDBAccount which will be used to
                   generate root account / password.
                   this account is generated if not exists, and a name is chosen based
-                  on a naming convention if not present
+                  on a naming convention if not present.
+                  See Galera->Status->RootDatabaseAccount for the actual name in use
+                  regardless of whether this field is set
                 type: string
               secret:
                 description: |-
@@ -305,6 +307,11 @@ spec:
                   the opentack-operator in the top-level CR (e.g. the ContainerImage)
                 format: int64
                 type: integer
+              rootDatabaseAccount:
+                description: |-
+                  RootDatabaseAccount - name of MariaDBAccount being used to maintain
+                  the RootDatabaseSecret.
+                type: string
               rootDatabaseSecret:
                 description: name of the Secret that is being used for the root password
                 type: string

--- a/internal/controller/galera_controller.go
+++ b/internal/controller/galera_controller.go
@@ -651,12 +651,22 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		return ctrl.Result{}, err
 	}
 
-	// the current root secret for the MariaDBAccount name is copied out to Status.
-	// this allows us to avoid having to change the Spec.
-	// Also by trying to always use CurrentSecret if available, we try to keep
-	// instance.Status.RootDatabaseSecret as the secret that should work for
-	// root right now, independent of changes in the mariadbaccount name
-	// or its secret that have not been reconciled w/ a new job hash.
+	// copy out the name of the MariaDBAccount in use to Status, so that it can
+	// be located by the user for modification (OSPRH-27668). While the
+	// RootDatabaseAccount is also part of instance.Spec, that field defaults
+	// to blank to indicate a naming convention is to be used; the status field
+	// shows the actual name in use regardless of whether it was manually set
+	// or naming-convention generated.
+	instance.Status.RootDatabaseAccount = mariaDBAccount.Name
+
+	// also copy out the name of the Secret linked to the above MariaDBAccount
+	// to Status, favoring its CurrentSecret field (e.g. the effective secret
+	// right now) above all.  CurrentSecret functions as the canonical source
+	// of the root DB password for the Galera instance as it is currently set.
+	// Updates to the MariaDBAccount->Secret may be made independently, which
+	// will be reflected as an update in this field once the MariaDBAccount has
+	// been reconciled with a new job hash (e.g. the actual DB password is
+	// updated in the galera instance).
 	if mariaDBAccount.Status.CurrentSecret != "" {
 		instance.Status.RootDatabaseSecret = mariaDBAccount.Status.CurrentSecret
 	} else if instance.Status.RootDatabaseSecret == "" {

--- a/test/chainsaw/common/galera-assert.yaml
+++ b/test/chainsaw/common/galera-assert.yaml
@@ -8,6 +8,8 @@ spec:
   storageRequest: 500M
 status:
   bootstrapped: true
+  rootDatabaseAccount: openstack-mariadb-root
+  rootDatabaseSecret: openstack-mariadb-root-db-secret
   conditions:
   - message: Setup complete
     reason: Ready

--- a/test/chainsaw/tests/galera-topology/galera-topology-assert.yaml
+++ b/test/chainsaw/tests/galera-topology/galera-topology-assert.yaml
@@ -10,6 +10,8 @@ spec:
     name: galera-topology
 status:
   bootstrapped: true
+  rootDatabaseAccount: openstack-mariadb-root
+  rootDatabaseSecret: openstack-mariadb-root-db-secret
   conditions:
   - message: Setup complete
     reason: Ready

--- a/test/chainsaw/tests/update-root-pw/galera-status-assert.yaml
+++ b/test/chainsaw/tests/update-root-pw/galera-status-assert.yaml
@@ -3,6 +3,7 @@ kind: Galera
 metadata:
   name: openstack
 status:
+  rootDatabaseAccount: openstack-mariadb-root
   # Verify that rootDatabaseSecret has been updated to the new secret
   rootDatabaseSecret: new-root-secret
   bootstrapped: true


### PR DESCRIPTION
Add a new field Galera->Status->rootDatabaseAccount indicating the current effective MariaDBAccount, in a similar way as Galera->Status->rootDatabaseSecret.  This is for informational purposes to indicate the name of the MariaDBAccount in use, as the Galera->Spec->rootDatabaseAccount field is normally going to remain blank, as it was introduced later on and defaults to using a generated naming convention.

References: [OSPRH-27668](https://redhat.atlassian.net/browse/OSPRH-27668)