### PR TITLE
[b/r] Add backup/restore labels to GaleraBackup CRD and PVCs

### DIFF
--- a/api/bases/mariadb.openstack.org_galerabackups.yaml
+++ b/api/bases/mariadb.openstack.org_galerabackups.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: galerabackups.mariadb.openstack.org
 spec:
   group: mariadb.openstack.org

--- a/api/go.mod
+++ b/api/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260316100655-863ae03d41af
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260326092926-8a2950f0575b
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260410120633-3e1007da0cbd
 	k8s.io/api v0.31.14
 	k8s.io/apimachinery v0.31.14
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d

--- a/api/go.sum
+++ b/api/go.sum
@@ -98,8 +98,8 @@ github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e h1:E1OdwSpqWuDPCedyU
 github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260316100655-863ae03d41af h1:Ow12j/PVbEtul1bZ7s/ZenVnKPIHK2q+0VgTp+j/wro=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260316100655-863ae03d41af/go.mod h1:nC/Jf3OYJRML8UEzJ/mn/TQcSCv/nhqO6x6LGkdDt60=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260326092926-8a2950f0575b h1:0YoXBWZfzax1Em7o1Li/wp9MB2JpcFWXiF7geTQohw0=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260326092926-8a2950f0575b/go.mod h1:XUUV+h1nZC4kra5oF+cXPkviWYJ3ELhccHxnVO7CvQQ=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260410120633-3e1007da0cbd h1:q00Fn4p6+0bFn/z4V3QukfxFoGJqP1bOkz12KqpFLpI=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260410120633-3e1007da0cbd/go.mod h1:I/VBXZLdjk8DUGsEbB+Ha72JBFYYntP7Pm2FpEto9K8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/api/v1beta1/galerabackup_types.go
+++ b/api/v1beta1/galerabackup_types.go
@@ -63,6 +63,9 @@ type GaleraBackupStatus struct {
 //+kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[0].status",description="Ready"
 // +kubebuilder:printcolumn:name="Message",type="string",JSONPath=".status.conditions[0].message",description="Message"
+//+kubebuilder:metadata:labels=backup.openstack.org/restore=true
+//+kubebuilder:metadata:labels=backup.openstack.org/category=controlplane
+//+kubebuilder:metadata:labels=backup.openstack.org/restore-order=40
 
 // GaleraBackup is the Schema for the galerabackups API
 type GaleraBackup struct {

--- a/config/crd/bases/mariadb.openstack.org_galerabackups.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galerabackups.yaml
@@ -4,6 +4,10 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
+  labels:
+    backup.openstack.org/category: controlplane
+    backup.openstack.org/restore: "true"
+    backup.openstack.org/restore-order: "40"
   name: galerabackups.mariadb.openstack.org
 spec:
   group: mariadb.openstack.org

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260316100655-863ae03d41af
-	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260326092926-8a2950f0575b
+	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260410120633-3e1007da0cbd
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.0.0-00010101000000-000000000000
 	go.uber.org/zap v1.27.1
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e h1:E1OdwSpqWuDPCedyU
 github.com/openshift/api v0.0.0-20250711200046-c86d80652a9e/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260316100655-863ae03d41af h1:Ow12j/PVbEtul1bZ7s/ZenVnKPIHK2q+0VgTp+j/wro=
 github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20260316100655-863ae03d41af/go.mod h1:nC/Jf3OYJRML8UEzJ/mn/TQcSCv/nhqO6x6LGkdDt60=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260326092926-8a2950f0575b h1:0YoXBWZfzax1Em7o1Li/wp9MB2JpcFWXiF7geTQohw0=
-github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260326092926-8a2950f0575b/go.mod h1:XUUV+h1nZC4kra5oF+cXPkviWYJ3ELhccHxnVO7CvQQ=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260410120633-3e1007da0cbd h1:q00Fn4p6+0bFn/z4V3QukfxFoGJqP1bOkz12KqpFLpI=
+github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20260410120633-3e1007da0cbd/go.mod h1:I/VBXZLdjk8DUGsEbB+Ha72JBFYYntP7Pm2FpEto9K8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/controller/galerabackup_controller.go
+++ b/internal/controller/galerabackup_controller.go
@@ -296,40 +296,51 @@ func (r *GaleraBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	pvc := &corev1.PersistentVolumeClaim{}
 	backupPVC, transferPVC := backup.BackupPVCs(instance, galera)
 
-	err = r.Get(ctx, types.NamespacedName{Name: backupPVC.Name, Namespace: backupPVC.Namespace}, backupPVC)
-	if err != nil && k8s_errors.IsNotFound(err) {
-		pvc.ObjectMeta = backupPVC.ObjectMeta
-		op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), pvc, func() error {
+	pvc.Name = backupPVC.Name
+	pvc.Namespace = backupPVC.Namespace
+	op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), pvc, func() error {
+		// Only set PVC spec on creation. Some fields (StorageClassName,
+		// AccessModes) are immutable after creation and others (like storage
+		// size increase) should be performed manually by the user.
+		if pvc.CreationTimestamp.IsZero() {
 			pvc.Spec = backupPVC.Spec
-			// We explicitely do not own this PVC so that backups are not lost
-			// if the GaleraBackup CR is removed
+		}
+		pvc.Labels = util.MergeStringMaps(pvc.Labels, backupPVC.Labels)
+		pvc.Annotations = util.MergeStringMaps(pvc.Annotations, backupPVC.Annotations)
+		// We explicitely do not own this PVC so that backups are not lost
+		// if the GaleraBackup CR is removed
+		return nil
+	})
+	if err != nil {
+		helper.GetLogger().Error(err, "CreateOrPatch failed", "pvc", pvc)
+		return ctrl.Result{}, err
+	}
+	helper.GetLogger().Info(fmt.Sprintf("Backup PVC %s - %s", pvc.Name, op))
+
+	if instance.Spec.TransferStorage != nil {
+		pvc = &corev1.PersistentVolumeClaim{}
+		pvc.Name = transferPVC.Name
+		pvc.Namespace = transferPVC.Namespace
+		op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), pvc, func() error {
+			// Only set PVC spec on creation. Some fields (StorageClassName,
+			// AccessModes) are immutable after creation and others (like storage
+			// size increase) should be performed manually by the user.
+			if pvc.CreationTimestamp.IsZero() {
+				pvc.Spec = transferPVC.Spec
+			}
+			pvc.Labels = util.MergeStringMaps(pvc.Labels, transferPVC.Labels)
+			pvc.Annotations = util.MergeStringMaps(pvc.Annotations, transferPVC.Annotations)
+			err := controllerutil.SetControllerReference(helper.GetBeforeObject(), pvc, helper.GetScheme())
+			if err != nil {
+				return err
+			}
 			return nil
 		})
 		if err != nil {
 			helper.GetLogger().Error(err, "CreateOrPatch failed", "pvc", pvc)
 			return ctrl.Result{}, err
 		}
-		helper.GetLogger().Info(fmt.Sprintf("Backup PVC %s - %s", pvc.Name, op))
-	}
-
-	if instance.Spec.TransferStorage != nil {
-		err = r.Get(ctx, types.NamespacedName{Name: transferPVC.Name, Namespace: transferPVC.Namespace}, transferPVC)
-		if err != nil && k8s_errors.IsNotFound(err) {
-			pvc.ObjectMeta = transferPVC.ObjectMeta
-			op, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), pvc, func() error {
-				pvc.Spec = transferPVC.Spec
-				err := controllerutil.SetControllerReference(helper.GetBeforeObject(), pvc, helper.GetScheme())
-				if err != nil {
-					return err
-				}
-				return nil
-			})
-			if err != nil {
-				helper.GetLogger().Error(err, "CreateOrPatch failed", "pvc", pvc)
-				return ctrl.Result{}, err
-			}
-			helper.GetLogger().Info(fmt.Sprintf("Backup transfer PVC %s - %s", pvc.Name, op))
-		}
+		helper.GetLogger().Info(fmt.Sprintf("Backup transfer PVC %s - %s", pvc.Name, op))
 	}
 
 	instance.Status.Conditions.MarkTrue(

--- a/internal/mariadb/backup/pvc.go
+++ b/internal/mariadb/backup/pvc.go
@@ -1,6 +1,8 @@
 package mariadbbackup
 
 import (
+	"github.com/openstack-k8s-operators/lib-common/modules/common/backup"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
@@ -24,6 +26,10 @@ func BackupPVCs(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) (*corev1.Persist
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backupName,
 			Namespace: b.Namespace,
+			Labels: util.MergeStringMaps(
+				backup.GetBackupLabels(backup.CategoryControlPlane),
+				backup.GetRestoreLabels(backup.RestoreOrder00, backup.CategoryControlPlane),
+			),
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{


### PR DESCRIPTION
Add backup/restore CRD labels to GaleraBackup for restore ordering. Label GaleraBackup PVCs for backup selection.

Remove the Get+IsNotFound guard so CreateOrPatch always runs, ensuring existing PVCs get backup/restore labels added on reconcile. PVC spec is only set on creation since some fields are immutable and others (like storage size) should be changed manually by the user.

Jira: [OSPRH-22912](https://redhat.atlassian.net/browse/OSPRH-22912)
Jira: [OSPRH-22913](https://redhat.atlassian.net/browse/OSPRH-22913)
Jira: [OSPRH-27012](https://redhat.atlassian.net/browse/OSPRH-27012)

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/680