### PR TITLE
improve fallback PW check for upgrades, harden against broken installs

### DIFF
--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -102,7 +102,10 @@ function kolla_update_db_root_pw {
     mysql -u root <<EOF
 FLUSH PRIVILEGES;
 ALTER USER 'root'@'localhost' IDENTIFIED BY '$DB_ROOT_PASSWORD';
-ALTER USER 'root'@'%'  IDENTIFIED BY '$DB_ROOT_PASSWORD';
+-- create root@% if missing (e.g. dropped during a failed password rotation)
+CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED BY '$DB_ROOT_PASSWORD';
+ALTER USER 'root'@'%' IDENTIFIED BY '$DB_ROOT_PASSWORD';
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
 EOF
 

--- a/templates/galera/bin/mysql_root_auth.sh
+++ b/templates/galera/bin/mysql_root_auth.sh
@@ -122,7 +122,7 @@ fi
 # spec directly.  assume we are in root pw flight
 if [ "${PASSWORD_VALID}" = "false" ]; then
 
-    MARIADB_ACCOUNT=$(echo "${GALERA_CR}" | python3 -c "import json, sys; print(json.load(sys.stdin)['spec']['rootDatabaseAccount'] or '${GALERA_INSTANCE}-mariadb-root')")
+    MARIADB_ACCOUNT=$(echo "${GALERA_CR}" | python3 -c "import json, sys; print(json.load(sys.stdin)['spec'].get('rootDatabaseAccount', '') or '${GALERA_INSTANCE}-mariadb-root')")
 
     MARIADB_ACCOUNT_CR=$(curl -s \
         --cacert ${CACERT} \

--- a/test/chainsaw/tests/root-pw-fallback/chainsaw-test.yaml
+++ b/test/chainsaw/tests/root-pw-fallback/chainsaw-test.yaml
@@ -1,0 +1,148 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: root-pw-fallback
+spec:
+  steps:
+  - name: Deploy 3-node cluster
+    description: Deploy a 3-node galera cluster
+    bindings:
+    - name: replicas
+      value: 3
+    try:
+    - apply:
+        file: ../../common/galera.yaml
+    - assert:
+        file: ../../common/galera-assert.yaml
+
+  - name: Verify initial root account exists
+    description: Verify the root MariaDBAccount exists with initial secret
+    try:
+    - assert:
+        file: root-account-initial-assert.yaml
+
+  - name: Capture original password and delete root at percent
+    description: >
+      Save the current root password, then DROP the root@% user.
+      This keeps root@localhost working (probes stay healthy) but
+      makes remote TCP connections made as root fail from any other host.
+      The DROP replicates across all galera nodes.
+    try:
+    - script:
+        content: |
+          SECRET_NAME=$(oc get galera openstack -n ${NAMESPACE} -o jsonpath='{.status.rootDatabaseSecret}')
+          ORIG_PW=$(oc get secret $SECRET_NAME -n ${NAMESPACE} -o jsonpath='{.data.DatabasePassword}' | base64 -d)
+          if [ -z "${ORIG_PW}" ]; then
+            echo "FAIL: Could not capture original password"
+            exit 1
+          fi
+          echo -n "${ORIG_PW}"
+        outputs:
+        - name: orig_pw
+          value: ($stdout)
+    - script:
+        env:
+        - name: ORIG_PW
+          value: ($orig_pw)
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c "
+            mysql -uroot -p'${ORIG_PW}' -e \"DROP USER 'root'@'%'; FLUSH PRIVILEGES;\"
+          "
+          echo "Dropped root@% user (replicates to all nodes)"
+    - script:
+        env:
+        - name: ORIG_PW
+          value: ($orig_pw)
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c "
+            mysql -uroot -p'${ORIG_PW}' -e 'SELECT 1' > /dev/null
+          "
+          echo "Verified root@localhost still works"
+
+  - name: Test fallback path from a remote host
+    description: >
+      From galera-1, run mysql_root_auth.sh with MYSQL_REMOTE_HOST
+      pointing to galera-0.  Since root@% is gone, the primary
+      password check fails (TCP connection rejected), PASSWORD_VALID
+      stays false and the second "fallback" access of the cluster occurs,
+      which is what we want to exercise here.
+    try:
+    - script:
+        content: |
+          SECRET_NAME=$(oc get galera openstack -n ${NAMESPACE} -o jsonpath='{.status.rootDatabaseSecret}')
+          ORIG_PW=$(oc get secret $SECRET_NAME -n ${NAMESPACE} -o jsonpath='{.data.DatabasePassword}' | base64 -d)
+          echo -n "${ORIG_PW}"
+        outputs:
+        - name: orig_pw
+          value: ($stdout)
+    - script:
+        content: |
+          RESULT=$(oc exec -n ${NAMESPACE} -c galera openstack-galera-1 -- /bin/sh -c '
+            rm -f /var/local/my.cnf/mysql_pw_cache.cnf
+            export MYSQL_REMOTE_HOST=openstack-galera-0.openstack-galera
+            source /var/lib/operator-scripts/mysql_root_auth.sh 2>&1
+            echo "MYSQL_PWD=${MYSQL_PWD}"
+          ')
+          echo "${RESULT}"
+        outputs:
+        - name: result
+          value: ($stdout)
+    - script:
+        env:
+        - name: RESULT
+          value: ($result)
+        content: |
+          # Verify the WARNING message appeared (proves primary path
+          # failed and we entered the fallback block)
+          if ! echo "${RESULT}" | grep -q "primary password retrieved from cluster failed authentication"; then
+            echo "FAIL: Expected WARNING about primary password failure not found"
+            exit 1
+          fi
+          echo "PASS: Primary password failure WARNING present"
+    - script:
+        env:
+        - name: RESULT
+          value: ($result)
+        - name: ORIG_PW
+          value: ($orig_pw)
+        content: |
+          # Verify MYSQL_PWD was set to the original password.
+          if ! echo "${RESULT}" | grep -q "MYSQL_PWD=${ORIG_PW}"; then
+            echo "FAIL: MYSQL_PWD should be '${ORIG_PW}' (from fallback MariaDBAccount)"
+            exit 1
+          fi
+          echo "PASS: Fallback path resolved correct password from MariaDBAccount"
+
+  - name: Restore root at percent user
+    description: Restore the root@% user so the cluster is fully functional again
+    try:
+    - script:
+        content: |
+          SECRET_NAME=$(oc get galera openstack -n ${NAMESPACE} -o jsonpath='{.status.rootDatabaseSecret}')
+          ORIG_PW=$(oc get secret $SECRET_NAME -n ${NAMESPACE} -o jsonpath='{.data.DatabasePassword}' | base64 -d)
+          echo -n "${ORIG_PW}"
+        outputs:
+        - name: orig_pw
+          value: ($stdout)
+    - script:
+        env:
+        - name: ORIG_PW
+          value: ($orig_pw)
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-0 -- /bin/sh -c "
+            mysql -uroot -p'${ORIG_PW}' -e \"
+              CREATE USER 'root'@'%' IDENTIFIED BY '${ORIG_PW}';
+              GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+              FLUSH PRIVILEGES;
+            \"
+          "
+          echo "Restored root@% user"
+    - script:
+        env:
+        - name: ORIG_PW
+          value: ($orig_pw)
+        content: |
+          oc exec -n ${NAMESPACE} -c galera openstack-galera-1 -- /bin/sh -c "
+            mysql -h openstack-galera-0.openstack-galera -uroot -p'${ORIG_PW}' -e 'SELECT 1' > /dev/null
+          "
+          echo "Verified remote root access restored"

--- a/test/chainsaw/tests/root-pw-fallback/root-account-initial-assert.yaml
+++ b/test/chainsaw/tests/root-pw-fallback/root-account-initial-assert.yaml
@@ -1,0 +1,10 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: MariaDBAccount
+metadata:
+  name: openstack-mariadb-root
+spec:
+  userName: root
+  secret: openstack-mariadb-root-db-secret
+  accountType: System
+status:
+  currentSecret: openstack-mariadb-root-db-secret


### PR DESCRIPTION
Testing has shown it's possible to deploy with pre-FR5 versions with passwords that interfere with bootstrap, leading to the "root@%" account missing entirely. Ensure bootstrap makes sure this is there for recovery scenarios.

Additionally, an FR4 deploy may have the "rootDatabaseAccount" key omitted entirely from the CR. Make the python fetch more robust and add a test that simulates the full scenario that was observed.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
(cherry picked from commit 974e1fe8649d021bbc7b7d340ea9eab35e03edf9)

Jira: [OSPRH-29205](https://redhat.atlassian.net/browse/OSPRH-29205)