### PR TITLE
fix maintenance of /var/local/my.cnf/ directory

### DIFF
--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -2,22 +2,6 @@
 set +eux
 
 
-# prepare space for mysql_root_auth.sh to place pw cache file
-sudo mkdir -p /var/local/my.cnf
-sudo chown mysql:mysql /var/local/my.cnf
-
-# set up $DB_ROOT_PASSWORD.
-# disable my.cnf caching in mysql_root_auth.sh, so that we definitely
-# use the root password defined in the cluster.   this should create
-# a new file in /var/local/my.cnf/
-# OSPRH-27031: Conditional sourcing for backwards compatibility with old pods
-# where script is updated but mysql_root_auth.sh is not yet available
-if [ -f /var/lib/operator-scripts/mysql_root_auth.sh ]; then
-    MYSQL_ROOT_AUTH_BYPASS_CHECKS=true source /var/lib/operator-scripts/mysql_root_auth.sh
-else
-    export MYSQL_PWD="${DB_ROOT_PASSWORD}"
-fi
-
 
 function kolla_update_db_root_pw {
     # update the root password given a set of mariadb datafiles
@@ -114,11 +98,54 @@ EOF
 }
 
 
-if [ -e /var/lib/mysql/mysql ]; then
-    echo -e "Database already exists. Reuse it."
+function kolla_set_all_configs {
+    # set up mounts, permissions, required files
+
     # set up permissions of mounted directories before starting
     # galera or the sidecar logging container
+    # NOTE: kolla_set_configs is explicitly allowed in sudoers and needs
+    # sudo to set up permissions
     sudo -E kolla_set_configs
+
+    # now that /var/local/ is owned by mysql, prepare space for invocations of
+    # mysql_root_auth.sh to place pw cache file. we do this by running the
+    # mysql_root_auth.sh which will also set up $DB_ROOT_PASSWORD for the
+    # remainder of this script.
+    #
+    # OSPRH-27031: The conditional is for backwards compatibility with old pods
+    # where script is updated but mysql_root_auth.sh is not yet available; in those
+    # cases we rely upon DB_ROOT_PASSWORD already part of the pods environment as
+    # was the case before the introduction of mysql_root_auth.sh.
+    #
+    if [ -f /var/lib/operator-scripts/mysql_root_auth.sh ]; then
+        # MYSQL_ROOT_AUTH_BYPASS_CHECKS=true: disable my.cnf caching in
+        # mysql_root_auth.sh, so that we definitely use the root password defined in
+        # the cluster, not whatever possibly stale PW is in local files.
+        MYSQL_ROOT_AUTH_BYPASS_CHECKS=true source /var/lib/operator-scripts/mysql_root_auth.sh
+    else
+        echo -e "Could not access /var/lib/operator-scripts/mysql_root_auth.sh script; "
+        echo -e "using environment DB_ROOT_PASSWORD and creating pw cache directory manually"
+        export MYSQL_PWD="${DB_ROOT_PASSWORD}"
+
+        PW_CACHE_DIR=/var/local/my.cnf
+
+        mkdir -p ${PW_CACHE_DIR}
+        chown mysql:mysql ${PW_CACHE_DIR}
+        echo -e "Created ${PW_CACHE_DIR} pw cache directory and set ownership"
+    fi
+
+}
+
+if [ -e /var/lib/mysql/mysql ]; then
+    echo -e "Database already exists. Reuse it."
+
+    # ensure at least an empty galera.cnf is present, which may not be
+    # the case in some pod restart scenarios.   kolla_set_configs will want
+    # this file to be present before writing to it.
+    touch /var/lib/config-data/generated/galera.cnf
+
+    kolla_set_all_configs
+
     kolla_update_db_root_pw
 else
     echo -e "Creating new mariadb database."
@@ -132,7 +159,9 @@ else
 bind_address=localhost
 wsrep_provider=none
 EOF
-    sudo -E kolla_set_configs
+
+    kolla_set_all_configs
+
     kolla_extend_start
 fi
 

--- a/templates/galera/bin/mysql_root_auth.sh
+++ b/templates/galera/bin/mysql_root_auth.sh
@@ -159,7 +159,9 @@ DB_ROOT_PASSWORD="${PASSWORD}"
 PW_CACHE_DIR=$(dirname "${PW_CACHE_FILE}")
 if [ ! -d "${PW_CACHE_DIR}" ]; then
     if ! mkdir -p "${PW_CACHE_DIR}" 2>/dev/null; then
-        echo "WARNING: Failed to create directory ${PW_CACHE_DIR} due to permissions; will try again later" >&2
+        echo "Did not yet create directory ${PW_CACHE_DIR} due to permissions; will try again later" >&2
+    else
+        echo "Created password cache directory ${PW_CACHE_DIR}" >&2
     fi
 fi
 
@@ -175,13 +177,17 @@ then
     # we are called for the first time from detect_gcomm_and_start.sh which is
     # called **before** kolla can set directory permissions; so when writing
     # the file, proceed even if we can't write the file yet
-    echo "WARNING: Failed to write to ${PW_CACHE_FILE} due to permissions; will try again later" >&2
+    echo "Did not yet write to ${PW_CACHE_FILE} due to permissions; will try again later" >&2
+else
+    echo "Wrote new credentials to ${PW_CACHE_FILE}" >&2
 fi
 
 # Set restrictive permissions on .my.cnf (only if file was successfully written)
 if [ -f "${PW_CACHE_FILE}" ]; then
     if ! chmod 600 "${PW_CACHE_FILE}" 2>/dev/null; then
-        echo "WARNING: Failed to set permissions on ${PW_CACHE_FILE}; will try again later" >&2
+        echo "Did not yet set permissions on ${PW_CACHE_FILE}; will try again later" >&2
+    else
+        echo "Set chmod 600 on ${PW_CACHE_FILE}" >&2
     fi
 fi
 


### PR DESCRIPTION
We can't rely upon /var/local being accessible to the mysql user before kolla_set_configs runs, so move these steps to be subsequent to kolla_set_configs.  we can't use "sudo" either as we run as mysql and we're not in sudoers
(kolla_set_configs has an explicit exception).   Improve
invocation of mysql_root_auth.sh so that it's first
run when it can successfully create the cache file, and improve
logging to show success cases as well as softer language for the
"will try again" case.

An observed environment saw the mysql init process go incorrectly where the root PW was not correctly set, this may or may not be related to cases where /var/local wasn't accessible.  however, in any case this change should fix warnings and failures and provide for a clean mysql_bootstrap.sh log.

(cherry picked from commit 1487a0e7a5c441ad9cd86b228f9d734cb18ed99d)

Jira: [OSPRH-29205](https://redhat.atlassian.net/browse/OSPRH-29205)