### PR TITLE
Increase hard-coded liveness and readiness probe timeouts

### DIFF
--- a/internal/mariadb/statefulset.go
+++ b/internal/mariadb/statefulset.go
@@ -149,6 +149,8 @@ func getGaleraContainers(g *mariadbv1.Galera, configHash string) []corev1.Contai
 					Command: []string{"/bin/bash", "/var/lib/operator-scripts/mysql_probe.sh", "liveness"},
 				},
 			},
+			// Do not rely on the default timeout (1s)
+			TimeoutSeconds: 5,
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -156,6 +158,8 @@ func getGaleraContainers(g *mariadbv1.Galera, configHash string) []corev1.Contai
 					Command: []string{"/bin/bash", "/var/lib/operator-scripts/mysql_probe.sh", "readiness"},
 				},
 			},
+			// Do not rely on the default timeout (1s)
+			TimeoutSeconds: 5,
 		},
 		Lifecycle: &corev1.Lifecycle{
 			PreStop: &corev1.LifecycleHandler{


### PR DESCRIPTION
Liveness and readiness probes currently rely on the default timeout of 1s, which is low and might cause unecessary instabilities on loaded environment.
Set an explicit default of 5s, until we move to configurable timeouts with the help of lib-common's functions.