### PR TITLE
Fix ansible test warnings and errors

### DIFF
--- a/test/ansible/ansible.cfg
+++ b/test/ansible/ansible.cfg
@@ -10,7 +10,7 @@ roles_path = ./roles
 collections_paths = ~/.ansible/collections:/usr/share/ansible/collections
 
 # Output
-stdout_callback = yaml
+result_format = yaml
 callbacks_enabled = profile_tasks, timer
 
 # Behavior

--- a/test/ansible/inventory
+++ b/test/ansible/inventory
@@ -1,2 +1,2 @@
-[localhost]
+[local]
 localhost ansible_connection=local

--- a/test/ansible/playbooks/mariadb-operator-update.yaml
+++ b/test/ansible/playbooks/mariadb-operator-update.yaml
@@ -28,7 +28,7 @@
           - "Galera CR: {{ galera_cr }}"
           - "Galera replicas: {{ replicas }}"
           - "Disruption: {{ disruption }}"
-          - "Namespace: {{ namespace }}"
+          - "Namespace: {{ cr_namespace }}"
       tags:
         - always
 

--- a/test/ansible/tasks/cleanup_environment.yaml
+++ b/test/ansible/tasks/cleanup_environment.yaml
@@ -5,7 +5,7 @@
     target: mariadb_deploy_cleanup
   environment:
     DBSERVICE: "{{ db_service }}"
-    NAMESPACE: "{{ namespace }}"
+    NAMESPACE: "{{ cr_namespace }}"
     MARIADB_CR: "{{ galera_cr }}"
     OUT: "{{ tmp_dir }}"
     TIMEOUT: "{{ deployment_timeout }}"
@@ -14,7 +14,7 @@
 
 - name: Wait until the Galera CR is deleted
   ansible.builtin.shell: >
-    oc -n {{ namespace }} wait --for=delete --timeout={{ deployment_timeout }} galera/openstack
+    oc -n {{ cr_namespace }} wait --for=delete --timeout={{ deployment_timeout }} galera/openstack
   changed_when: false
   tags:
     - cleanup
@@ -26,7 +26,7 @@
   environment:
     MARIADB_IMG: "{{ mariadb_operator_image_initial }}"
     OPERATOR_NAMESPACE: "{{ operator_namespace }}"
-    NAMESPACE: "{{ namespace }}"
+    NAMESPACE: "{{ cr_namespace }}"
     OUT: "{{ tmp_dir }}"
     TIMEOUT: "{{ deployment_timeout }}"
   tags:

--- a/test/ansible/tasks/deploy_resources.yaml
+++ b/test/ansible/tasks/deploy_resources.yaml
@@ -6,7 +6,7 @@
   environment:
     MARIADB_IMG: "{{ mariadb_operator_image_initial }}"
     OPERATOR_NAMESPACE: "{{ operator_namespace }}"
-    NAMESPACE: "{{ namespace }}"
+    NAMESPACE: "{{ cr_namespace }}"
     OUT: "{{ tmp_dir }}"
     TIMEOUT: "{{ deployment_timeout }}"
   tags:
@@ -45,7 +45,7 @@
     target: mariadb_deploy
   environment:
     DBSERVICE: "{{ db_service }}"
-    NAMESPACE: "{{ namespace }}"
+    NAMESPACE: "{{ cr_namespace }}"
     MARIADB_CR: "{{ galera_cr_prepared }}"
     OUT: "{{ tmp_dir }}"
     TIMEOUT: "{{ deployment_timeout }}"
@@ -54,11 +54,11 @@
 
 - name: Wait for all the Galera pods to be ready
   ansible.builtin.shell: >
-    oc -n {{ namespace }} wait --for=create --timeout={{ deployment_timeout }}
+    oc -n {{ cr_namespace }} wait --for=create --timeout={{ deployment_timeout }}
     galera/openstack &&
-    oc -n {{ namespace }} wait --for=condition=Ready --timeout={{ deployment_timeout }}
+    oc -n {{ cr_namespace }} wait --for=condition=Ready --timeout={{ deployment_timeout }}
     galera/openstack &&
-    oc -n {{ namespace }} wait --for=jsonpath='{.status.availableReplicas}={{ replicas }}' --timeout={{ deployment_timeout }}
+    oc -n {{ cr_namespace }} wait --for=jsonpath='{.status.availableReplicas}={{ replicas }}' --timeout={{ deployment_timeout }}
     statefulset/openstack-galera
   changed_when: false
   tags:

--- a/test/ansible/tasks/update_operator.yaml
+++ b/test/ansible/tasks/update_operator.yaml
@@ -5,7 +5,7 @@
     target: mariadb_cleanup
   environment:
     OPERATOR_NAMESPACE: "{{ operator_namespace }}"
-    NAMESPACE: "{{ namespace }}"
+    NAMESPACE: "{{ cr_namespace }}"
     TIMEOUT: "{{ update_timeout }}"
   tags:
     - update
@@ -27,7 +27,7 @@
   environment:
     MARIADB_IMG: "{{ mariadb_operator_image_updated }}"
     OPERATOR_NAMESPACE: "{{ operator_namespace }}"
-    NAMESPACE: "{{ namespace }}"
+    NAMESPACE: "{{ cr_namespace }}"
     TIMEOUT: "{{ deployment_timeout }}"
   tags:
     - update
@@ -42,21 +42,21 @@
 - name: Trigger a cluster stop during the galera rolling update
   when:
     - replicas == 3
-    - disruption
+    - disruption|bool
   tags:
     - update
   block:
     - name: Wait for the first Galera pod to be updated
       ansible.builtin.shell: >
-        oc -n {{ namespace }} wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].status}=False' --timeout={{ update_timeout }} pod/openstack-galera-2
+        oc -n {{ cr_namespace }} wait --for='jsonpath={.status.conditions[?(@.type=="Ready")].status}=False' --timeout={{ update_timeout }} pod/openstack-galera-2
       changed_when: false
       tags:
         - update
 
     - name: Restart the remaining Galera pod before the first one gets fully restarted
       ansible.builtin.shell: |
-        oc -n {{ namespace }} exec pod/openstack-galera-0 -- killall -s TERM mysqld
-        oc -n {{ namespace }} exec pod/openstack-galera-1 -- killall -s TERM mysqld
+        oc -n {{ cr_namespace }} exec -c galera pod/openstack-galera-0 -- killall -s TERM mysqld
+        oc -n {{ cr_namespace }} exec -c galera pod/openstack-galera-1 -- killall -s TERM mysqld
       changed_when: false
       tags:
         - update
@@ -64,15 +64,15 @@
 - name: Wait for all the Galera pods to be updated
   ansible.builtin.shell: |
     set -o pipefail
-    UPDATE_REV=$(oc -n {{ namespace }} get -o json statefulset/openstack-galera | jq -r .status.updateRevision)
-    oc -n {{ namespace }} wait --for=jsonpath="{.status.currentRevision}=${UPDATE_REV}" --timeout={{ update_timeout }} statefulset/openstack-galera
+    UPDATE_REV=$(oc -n {{ cr_namespace }} get -o json statefulset/openstack-galera | jq -r .status.updateRevision)
+    oc -n {{ cr_namespace }} wait --for=jsonpath="{.status.currentRevision}=${UPDATE_REV}" --timeout={{ update_timeout }} statefulset/openstack-galera
   changed_when: false
   tags:
     - update
 
 - name: Wait for all the Galera pods to be ready
   ansible.builtin.shell: |
-    oc -n {{ namespace }} wait --for=jsonpath="{.status.availableReplicas}={{ replicas }}" --timeout={{ update_timeout }} statefulset/openstack-galera
+    oc -n {{ cr_namespace }} wait --for=jsonpath="{.status.availableReplicas}={{ replicas }}" --timeout={{ update_timeout }} statefulset/openstack-galera
   changed_when: false
   tags:
     - update

--- a/test/ansible/vars/mariadb-operator-vars.yaml
+++ b/test/ansible/vars/mariadb-operator-vars.yaml
@@ -12,7 +12,7 @@ mariadb_operator_image_updated: "quay.io/openstack-k8s-operators/mariadb-operato
 disruption: true
 
 # Namespaces
-namespace: "openstack"
+cr_namespace: "openstack"
 operator_namespace: "openstack-operators"
 
 # Galera cluster configuration


### PR DESCRIPTION
New warnings and errors are reported with recent ansible versions:
  - use of reserved ansible var 'namespace'
  - name 'localhost' used as both a group and a host
  - stdout callback config being deprecated