### PR TITLE
Shorten name of resources created by galerabackup

### DIFF
--- a/internal/controller/galerabackup_controller.go
+++ b/internal/controller/galerabackup_controller.go
@@ -348,6 +348,19 @@ func (r *GaleraBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		mariadbv1.PersistentVolumeClaimReadyMessage,
 	)
 
+	// If a cronjob with the old naming convention, delete it here to avoid taking
+	// two backups for the target galera CR
+	oldCronJob := &batchv1.CronJob{}
+	oldName := galera.Name + "-backup-" + instance.Name
+	err = r.Get(ctx, types.NamespacedName{Name: oldName, Namespace: instance.Namespace}, oldCronJob)
+	if err == nil {
+		if err := r.Delete(ctx, oldCronJob); err != nil {
+			helper.GetLogger().Error(err, "Failed to delete old-format CronJob", "cronjob", oldName)
+			return ctrl.Result{}, err
+		}
+		helper.GetLogger().Info(fmt.Sprintf("Deleted old-format CronJob %s", oldName))
+	}
+
 	preparedBackupCronJob := backup.BackupCronJob(instance, galera, hashOfHashes)
 	backupCronJob := &batchv1.CronJob{}
 	backupCronJob.ObjectMeta = preparedBackupCronJob.ObjectMeta

--- a/internal/controller/galerarestore_controller.go
+++ b/internal/controller/galerarestore_controller.go
@@ -220,7 +220,7 @@ func (r *GaleraRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// the Pod's properties are taken from the pod template configured
 	// in the backup's cronjob.
 	backupCronJob := &batchv1.CronJob{}
-	backupCronJobName := backup.BackupCronJobName(galeraBackup, galera)
+	backupCronJobName := backup.BackupCronJobName(galeraBackup)
 	err = r.Get(ctx, types.NamespacedName{Name: backupCronJobName, Namespace: galeraBackup.Namespace}, backupCronJob)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {

--- a/internal/mariadb/backup/cronjob.go
+++ b/internal/mariadb/backup/cronjob.go
@@ -15,7 +15,7 @@ import (
 // BackupCronJob returns a CronJob object for the galera backup
 func BackupCronJob(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera, configHash string) *batchv1.CronJob {
 	ls := mariadb.StatefulSetLabels(g)
-	name := BackupCronJobName(b, g)
+	name := BackupCronJobName(b)
 	cronJob := &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -37,7 +37,7 @@ func BackupCronJob(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera, configHash st
 
 func getBackupPodTemplate(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera, configHash string) *corev1.PodTemplateSpec {
 	ls := mariadb.StatefulSetLabels(g)
-	prefixName := BackupCronJobName(b, g)
+	prefixName := BackupCronJobName(b)
 	svcName := g.Name + "-galera" // TODO use service name
 
 	// Option: retention

--- a/internal/mariadb/backup/pvc.go
+++ b/internal/mariadb/backup/pvc.go
@@ -11,7 +11,7 @@ import (
 
 // BackupPVCs returns the PVC objects used by the backup Job to transfer data and create a SQL backup
 func BackupPVCs(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) (*corev1.PersistentVolumeClaim, *corev1.PersistentVolumeClaim) {
-	backupName := BackupPVCName(b, g)
+	backupName := BackupPVCName(b)
 	backupSize, err := resource.ParseQuantity(b.Spec.StorageRequest)
 	if err != nil {
 		backupSize = resource.MustParse(g.Spec.StorageRequest)
@@ -48,7 +48,7 @@ func BackupPVCs(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) (*corev1.Persist
 		return backupPVC, nil
 	}
 
-	transferName := BackupTransferPVCName(b, g)
+	transferName := BackupTransferPVCName(b)
 	transferSize, err := resource.ParseQuantity(b.Spec.TransferStorage.StorageRequest)
 	if err != nil {
 		transferSize = resource.MustParse(g.Spec.StorageRequest)

--- a/internal/mariadb/backup/restorepod.go
+++ b/internal/mariadb/backup/restorepod.go
@@ -16,7 +16,8 @@ func RestorePod(restoreCR *mariadbv1.GaleraRestore, backupCR *mariadbv1.GaleraBa
 		Namespace: backupCR.Namespace,
 	}}
 
-	prefixName := RestorePodName(restoreCR, galeraCR)
+	ls := RestorePodLabels(restoreCR)
+	prefixName := RestorePodName(restoreCR)
 
 	environ := []corev1.EnvVar{{
 		Name:  "DB",
@@ -37,6 +38,7 @@ func RestorePod(restoreCR *mariadbv1.GaleraRestore, backupCR *mariadbv1.GaleraBa
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      prefixName,
 			Namespace: backupCR.Namespace,
+			Labels:    ls,
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyOnFailure,

--- a/internal/mariadb/backup/utils.go
+++ b/internal/mariadb/backup/utils.go
@@ -1,23 +1,31 @@
 package mariadbbackup
 
-import mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+import (
+	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+)
 
 // BackupCronJobName - name of the cronjob resource created for a backup CR
-func BackupCronJobName(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) string {
-	return g.Name + "-backup-" + b.Name
+func BackupCronJobName(b *mariadbv1.GaleraBackup) string {
+	return "backup-" + b.Name
 }
 
 // BackupPVCName returns the name of the PVC resource that stores .sql backup files
-func BackupPVCName(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) string {
-	return "mysql-backup-" + g.Name + "-backup-" + b.Name
+func BackupPVCName(b *mariadbv1.GaleraBackup) string {
+	return "mysql-backup-" + b.Name
 }
 
 // BackupTransferPVCName returns the name of the PVC resource that stores temporary binary backup data
-func BackupTransferPVCName(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) string {
-	return "mysql-transfer-" + g.Name + "-backup-" + b.Name
+func BackupTransferPVCName(b *mariadbv1.GaleraBackup) string {
+	return "mysql-transfer-" + b.Name
 }
 
 // RestorePodName - name of the pod resource created by a GaleraRestore CR
-func RestorePodName(r *mariadbv1.GaleraRestore, g *mariadbv1.Galera) string {
-	return g.Name + "-restore-" + r.Name
+func RestorePodName(r *mariadbv1.GaleraRestore) string {
+	return "restore-" + r.Name
+}
+
+// RestorePodLabels - common labels to map a pod to its associated GaleraRestore CR
+func RestorePodLabels(r *mariadbv1.GaleraRestore) map[string]string {
+	return labels.GetLabels(r, "galerarestore", map[string]string{})
 }

--- a/internal/mariadb/backup/volumes.go
+++ b/internal/mariadb/backup/volumes.go
@@ -70,7 +70,7 @@ func baseVolumes(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) []corev1.Volume
 		Name: "backup-data",
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-				ClaimName: BackupPVCName(b, g),
+				ClaimName: BackupPVCName(b),
 			},
 		},
 	}}
@@ -161,7 +161,7 @@ func BackupVolumes(b *mariadbv1.GaleraBackup, g *mariadbv1.Galera) []corev1.Volu
 			Name: "transfer-data",
 			VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: BackupTransferPVCName(b, g),
+					ClaimName: BackupTransferPVCName(b),
 				},
 			},
 		})

--- a/test/chainsaw/tests/backup-capture/assert-openstack2nd.yaml
+++ b/test/chainsaw/tests/backup-capture/assert-openstack2nd.yaml
@@ -15,9 +15,9 @@ metadata:
   labels:
     galera/name: cluster2
     owner: mariadb-operator
-  name: cluster2-backup-openstack2nd
+  name: backup-openstack2nd
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mysql-backup-cluster2-backup-openstack2nd
+  name: mysql-backup-openstack2nd

--- a/test/chainsaw/tests/backup-capture/chainsaw-test.yaml
+++ b/test/chainsaw/tests/backup-capture/chainsaw-test.yaml
@@ -24,7 +24,7 @@ spec:
     cleanup:
     - script:
         content: |
-          oc -n $NAMESPACE delete pvc mysql-backup-openstack-backup-openstack || true
+          oc -n $NAMESPACE delete pvc mysql-backup-openstack || true
 
   - name: setup a backup for a 1-node Galera cluster
     description: checks that backup CR is correctly set up
@@ -54,7 +54,7 @@ spec:
         - name: REPLICAS
           value: ($replicas)
         content: |
-          oc -n $NAMESPACE create job --from=cronjob/openstack-backup-openstack backup-${REPLICAS}node
+          oc -n $NAMESPACE create job --from=cronjob/backup-openstack backup-${REPLICAS}node
           oc -n $NAMESPACE wait --for=condition=complete job/backup-${REPLICAS}node
     - script: &backup_check
         env:
@@ -109,7 +109,7 @@ spec:
     cleanup:
     - script:
         content: |
-          oc -n $NAMESPACE delete pvc mysql-backup-cluster2-backup-openstack2nd || true
+          oc -n $NAMESPACE delete pvc mysql-backup-openstack2nd || true
 
 
   - name: backup the two running clusters
@@ -117,8 +117,8 @@ spec:
     try:
     - script:
         content: |
-          oc -n $NAMESPACE create job --from=cronjob/openstack-backup-openstack backup-1node
-          oc -n $NAMESPACE create job --from=cronjob/cluster2-backup-openstack2nd backup-1node-2nd
+          oc -n $NAMESPACE create job --from=cronjob/backup-openstack backup-1node
+          oc -n $NAMESPACE create job --from=cronjob/backup-openstack2nd backup-1node-2nd
     - script:
         content: |
           oc -n $NAMESPACE wait --for=condition=complete job/backup-1node job/backup-1node-2nd
@@ -130,7 +130,7 @@ spec:
     try:
     - script:
         content: |
-          oc -n $NAMESPACE create job --from=cronjob/openstack-backup-openstack custom-timestamp --dry-run=client -o json | jq '.spec.template.spec.containers[0].env += [{ "name": "BACKUP_TIMESTAMP", value:"chainsaw_unit_test" }]' | oc -n $NAMESPACE apply -f -
+          oc -n $NAMESPACE create job --from=cronjob/backup-openstack custom-timestamp --dry-run=client -o json | jq '.spec.template.spec.containers[0].env += [{ "name": "BACKUP_TIMESTAMP", value:"chainsaw_unit_test" }]' | oc -n $NAMESPACE apply -f -
     - script:
         content: |
           oc -n $NAMESPACE wait --for=condition=complete job/backup-1node

--- a/test/chainsaw/tests/backup-capture/galerabackup-assert.yaml
+++ b/test/chainsaw/tests/backup-capture/galerabackup-assert.yaml
@@ -37,12 +37,12 @@ metadata:
   labels:
     galera/name: openstack
     owner: mariadb-operator
-  name: openstack-backup-openstack
+  name: backup-openstack
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mysql-backup-openstack-backup-openstack
+  name: mysql-backup-openstack
 spec:
   resources:
     requests:

--- a/test/chainsaw/tests/backup-configs/chainsaw-test.yaml
+++ b/test/chainsaw/tests/backup-configs/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
     cleanup:
     - script:
         content: |
-          oc -n $NAMESPACE delete pvc mysql-backup-openstack-backup-openstack mysql-transfer-openstack-backup-openstack || true
+          oc -n $NAMESPACE delete pvc mysql-backup-openstack mysql-transfer-openstack || true
 
   - name: backup the 1-node Galera cluster
     description: checks that the cluster is correctly backed up
@@ -43,7 +43,7 @@ spec:
         - name: REPLICAS
           value: ($replicas)
         content: |
-          oc -n $NAMESPACE create job --from=cronjob/openstack-backup-openstack backup-${REPLICAS}node
+          oc -n $NAMESPACE create job --from=cronjob/backup-openstack backup-${REPLICAS}node
           oc -n $NAMESPACE wait --for=condition=complete job/backup-${REPLICAS}node
     - script:
         env:

--- a/test/chainsaw/tests/backup-configs/galerabackup-two-pvc-assert.yaml
+++ b/test/chainsaw/tests/backup-configs/galerabackup-two-pvc-assert.yaml
@@ -4,12 +4,12 @@ metadata:
   labels:
     galera/name: openstack
     owner: mariadb-operator
-  name: openstack-backup-openstack
+  name: backup-openstack
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mysql-backup-openstack-backup-openstack
+  name: mysql-backup-openstack
 spec:
   resources:
     requests:
@@ -19,7 +19,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mysql-transfer-openstack-backup-openstack
+  name: mysql-transfer-openstack
 spec:
   resources:
     requests:

--- a/test/chainsaw/tests/restore/chainsaw-test.yaml
+++ b/test/chainsaw/tests/restore/chainsaw-test.yaml
@@ -41,15 +41,15 @@ spec:
     cleanup:
     - script:
         content: |
-          oc -n $NAMESPACE delete pvc mysql-backup-cluster2-backup-cluster2backup mysql-backup-openstack-backup-openstackbackup || true
+          oc -n $NAMESPACE delete pvc mysql-backup-cluster2backup mysql-backup-openstackbackup || true
 
   - name: trigger a backup of Galera cluster
     description: checks that the cluster is correctly backed up
     try:
     - script:
         content: |
-          oc -n $NAMESPACE create job --from=cronjob/openstack-backup-openstackbackup backupjob1
-          oc -n $NAMESPACE create job --from=cronjob/cluster2-backup-cluster2backup backupjob2
+          oc -n $NAMESPACE create job --from=cronjob/backup-openstackbackup backupjob1
+          oc -n $NAMESPACE create job --from=cronjob/backup-cluster2backup backupjob2
           oc -n $NAMESPACE wait --for=condition=complete job/backupjob1
           oc -n $NAMESPACE wait --for=condition=complete job/backupjob2
 

--- a/test/chainsaw/tests/restore/openstackbackup-assert.yaml
+++ b/test/chainsaw/tests/restore/openstackbackup-assert.yaml
@@ -15,9 +15,9 @@ metadata:
   labels:
     galera/name: openstack
     owner: mariadb-operator
-  name: openstack-backup-openstackbackup
+  name: backup-openstackbackup
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mysql-backup-openstack-backup-openstackbackup
+  name: mysql-backup-openstackbackup


### PR DESCRIPTION
This prevents cases where instantiating job would fail when labels configured to set up the job exceed the k8s limit of 63 characters.

Note: by changing the naming convention of the pvc and cronjob generated for a galerabackup CR, we are leaving behind old resources.