### PR TITLE
Fix restart of mariadb operator during ansible tests

### DIFF
--- a/test/ansible/tasks/cleanup_environment.yaml
+++ b/test/ansible/tasks/cleanup_environment.yaml
@@ -31,3 +31,15 @@
     TIMEOUT: "{{ deployment_timeout }}"
   tags:
     - cleanup
+
+- name: Restore openstack-operator-controller-init config if needed
+  ansible.builtin.shell: |
+    set -o pipefail
+    PREV_REPLICAS=$(oc -n {{ operator_namespace }} get -o json deployment/openstack-operator-controller-init | jq -r '.metadata.labels["test.mariadb-operator/saved-replicas"] | select( . != null )')
+    if [ -n "${PREV_REPLICAS}" ]; then
+        oc -n {{ operator_namespace }} patch deployment/openstack-operator-controller-init --type='json' -p='[{"op":"replace","path":"/spec/replicas","value":'${PREV_REPLICAS}'}]'
+        oc -n {{ operator_namespace }} label deployment/openstack-operator-controller-init test.mariadb-operator/saved-replicas-
+    fi
+  changed_when: false
+  tags:
+    - cleanup

--- a/test/ansible/tasks/update_operator.yaml
+++ b/test/ansible/tasks/update_operator.yaml
@@ -20,6 +20,16 @@
   tags:
     - update
 
+- name: Disable openstack-operator-controller-init to allow custom mariadb-operator image
+  ansible.builtin.shell: |
+    set -o pipefail
+    PREV_REPLICAS=$(oc -n {{ operator_namespace }} get -o json deployment/openstack-operator-controller-init | jq -r .spec.replicas)
+    oc -n {{ operator_namespace }} label deployment/openstack-operator-controller-init test.mariadb-operator/saved-replicas="$PREV_REPLICAS"
+    oc -n {{ operator_namespace }} patch deployment/openstack-operator-controller-init --type='json' -p='[{"op":"replace","path":"/spec/replicas","value":0}]'
+  changed_when: false
+  tags:
+    - update
+
 - name: Update mariadb-operator to new image
   community.general.make:
     chdir: "{{ install_yamls_dir }}"


### PR DESCRIPTION
When the openstack-operator-controller-init is running, a custom mariadb-operator-index cannot create a mariadb-operator deployment with its associated custom mariadb-operator image.

Update the ansible test stop the openstack-operator-controller-init during the update, and restore it during the cleanup task.