### PR TITLE
Fix broken chainsaw tests for backup/restore

### DIFF
--- a/test/chainsaw/tests/restore/chainsaw-test.yaml
+++ b/test/chainsaw/tests/restore/chainsaw-test.yaml
@@ -92,21 +92,21 @@ spec:
         - name: BACKUPTIME2
           value: ($BACKUPTIME2)
         content: |
-          oc -n $NAMESPACE exec openstack-restore-openstackrestore -- find /backup/data -type f -not -newermt "@${BACKUPTIME1}" -delete -print
-          oc -n $NAMESPACE exec cluster2-restore-cluster2restore   -- find /backup/data -type f -not -newermt "@${BACKUPTIME2}" -delete -print
+          oc -n $NAMESPACE exec restore-openstackrestore -- find /backup/data -type f -not -newermt "@${BACKUPTIME1}" -delete -print
+          oc -n $NAMESPACE exec restore-cluster2restore  -- find /backup/data -type f -not -newermt "@${BACKUPTIME2}" -delete -print
 
   - name: trigger restores to the Galera clusters
     description: checks that the cluster is correctly backed up
     try:
     - script:
         content: |
-          oc -n $NAMESPACE exec openstack-restore-openstackrestore -- /var/lib/backup-scripts/restore_galera --yes /backup/data/*.gz
+          oc -n $NAMESPACE exec restore-openstackrestore -- /var/lib/backup-scripts/restore_galera --yes /backup/data/*.gz
           oc -n $NAMESPACE exec -c galera openstack-galera-0 -- mysql -nN -e 'show databases;'
         check:
           (contains($stdout, 'restore_test1')): true
     - script:
         content: |
-          oc -n $NAMESPACE exec cluster2-restore-cluster2restore -- /var/lib/backup-scripts/restore_galera --yes /backup/data/*.gz
+          oc -n $NAMESPACE exec restore-cluster2restore -- /var/lib/backup-scripts/restore_galera --yes /backup/data/*.gz
           oc -n $NAMESPACE exec -c galera cluster2-galera-0 -- mysql -nN -e 'show databases;'
         check:
           (contains($stdout, 'restore_test2')): true

--- a/test/chainsaw/tests/restore/cluster2backup-assert.yaml
+++ b/test/chainsaw/tests/restore/cluster2backup-assert.yaml
@@ -15,9 +15,6 @@ metadata:
   labels:
     galera/name: cluster2
     owner: mariadb-operator
-  name: cluster2-backup-cluster2backup
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mysql-backup-cluster2-backup-cluster2backup
+  name: backup-cluster2backup
+# PVC mysql-backup-cluster2backup is instantiated only after
+# a job has been created for Cronjob backup-cluster2backup

--- a/test/chainsaw/tests/restore/openstackbackup-assert.yaml
+++ b/test/chainsaw/tests/restore/openstackbackup-assert.yaml
@@ -16,8 +16,5 @@ metadata:
     galera/name: openstack
     owner: mariadb-operator
   name: backup-openstackbackup
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mysql-backup-openstackbackup
+# PVC mysql-backup-openstackbackup is instantiated only after
+# a job has been created for Cronjob backup-openstackbacup


### PR DESCRIPTION
Since the last bump of the operator SDK [1], the test directory has been renamed from "tests" to "test", and this broke the prow job that exercises chainsaw tests.

A recent commit [2] for improving backup/restore broke the chainsaw tests when running locally, so this commit fixes those tests.

[1] 03bf5129cb4ec15b5049d1baddaa4bb0dc68fa7c
[2] 2312ad5047f09327ddb4f6d47055f860a2312a52