### PR TITLE
Fix missing-dbrootpassword chainsaw test failing in CI

### DIFF
--- a/test/chainsaw/tests/missing-dbrootpassword/galera-assert.yaml
+++ b/test/chainsaw/tests/missing-dbrootpassword/galera-assert.yaml
@@ -6,7 +6,6 @@ spec:
   replicas: ($replicas)
   secret: test-secret-missing-dbrootpassword
   storageRequest: 500M
-  containerImage: quay.io/podified-antelope-centos9/openstack-mariadb:current-podified
 status:
   conditions:
   - message: Input data resources missing


### PR DESCRIPTION
Remove hardcoded containerImage from the assert file. The test applies a Galera CR without specifying containerImage, so the webhook defaults it. In CI the default is a sha256 digest, which never matches the hardcoded tag.