### PR TITLE
Fix restore chainsaw test race condition on pod readiness

### DIFF
--- a/test/chainsaw/tests/restore/chainsaw-test.yaml
+++ b/test/chainsaw/tests/restore/chainsaw-test.yaml
@@ -71,6 +71,31 @@ spec:
     - assert:
         file: cluster2restore-assert.yaml
 
+  - name: wait for restore pods to be running
+    try:
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: restore-openstackrestore
+          status:
+            phase: Running
+            containerStatuses:
+            - name: restore
+              ready: true
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: restore-cluster2restore
+          status:
+            phase: Running
+            containerStatuses:
+            - name: restore
+              ready: true
+
   - name: clean up previous files on the PV hosting backups
     try:
     - script:


### PR DESCRIPTION
The chainsaw restore test was failing because it tried to exec into restore pods immediately after the GaleraRestore CR became Ready, but the CR is marked Ready as soon as the pod is created, not when the container is actually running. This adds a step to assert pod container readiness before exec'ing into them.