### PR TITLE
Fix restore chainsaw test asserting wrong cluster name

### DIFF
--- a/test/chainsaw/tests/restore/cluster2-1node-assert.yaml
+++ b/test/chainsaw/tests/restore/cluster2-1node-assert.yaml
@@ -1,9 +1,25 @@
 apiVersion: mariadb.openstack.org/v1beta1
 kind: Galera
 metadata:
-  name: openstack
+  name: cluster2
 status:
   bootstrapped: true
-  (conditions[0:1]):
-    - type: Ready
-      status: "True"
+  conditions:
+  - type: Ready
+    status: "True"
+  - type: DeploymentReady
+    status: "True"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: cluster2-galera
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: cluster2-galera


### PR DESCRIPTION
The cluster2-1node-assert.yaml was asserting on name: openstack instead of name: cluster2, so the test never waited for the cluster2 Galera cluster to be ready. This caused a race condition where the next step tried to exec into cluster2-galera-0 before MySQL was accepting connections, resulting in socket connection errors.