### PR TITLE
Revert condition checks in restore chainsaw test

### DIFF
--- a/test/chainsaw/tests/restore/cluster2-1node-assert.yaml
+++ b/test/chainsaw/tests/restore/cluster2-1node-assert.yaml
@@ -4,22 +4,6 @@ metadata:
   name: cluster2
 status:
   bootstrapped: true
-  conditions:
-  - type: Ready
-    status: "True"
-  - type: DeploymentReady
-    status: "True"
----
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: cluster2-galera
-status:
-  availableReplicas: 1
-  readyReplicas: 1
-  replicas: 1
----
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: cluster2-galera
+  (conditions[0:1]):
+    - type: Ready
+      status: "True"


### PR DESCRIPTION
While fixing the restore chainsaw test, we changed the way we probe the conditions on the galera CR, and the explicit checks of subconditions causes the chainsaw assertion to fail due to condition size mismatch.

Revert to check only the subset of conditions we care about