### PR TITLE
Fix local operator run without Openstack CR

### DIFF
--- a/hack/run_with_local_webhook.sh
+++ b/hack/run_with_local_webhook.sh
@@ -167,7 +167,8 @@ if [ -n "${CSV_NAME}" ]; then
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/webhookdefinitions', 'value': []}]"
 else
-    if CR_NAME=$(oc get openstack -n openstack-operators -o name); then
+    CR_NAME="$(oc get openstack -n openstack-operators -o name)"
+    if [ -n "${CR_NAME}" ]; then
         printf \
         "\n\tNow patching openstack CR to scale down deployment resource.
         To restore it, use:


### PR DESCRIPTION
Recent commit [1] made use of Openstack CR overrides to scale down operators prior to run the mariadb-operator locally.

Make the script work even when no openstack CR exists.

[1] 73b5a025b0bcb65936e1639d89af6c7cc1db349e