### PR TITLE
Fix chainsaw test backup-capture

### DIFF
--- a/test/chainsaw/common/backup-assert.sh
+++ b/test/chainsaw/common/backup-assert.sh
@@ -3,8 +3,8 @@
 set -ue
 
 function finally {
-    if [ -n "${debugpod}" -a -n "$(oc get --ignore-not-found -o name ${debugpod})" ]; then
-        oc -n $NAMESPACE delete ${debugpod} --force
+    if [ -n "${jobpod:-}" ] && [ -n "$(oc get --ignore-not-found -o name "${jobpod}-debug")" ]; then
+        oc -n $NAMESPACE delete "${jobpod}-debug" --force
     fi
     rm -rf backup-assert
 }

--- a/test/chainsaw/tests/backup-capture/chainsaw-test.yaml
+++ b/test/chainsaw/tests/backup-capture/chainsaw-test.yaml
@@ -54,6 +54,7 @@ spec:
         - name: REPLICAS
           value: ($replicas)
         content: |
+          set -e
           oc -n $NAMESPACE create job --from=cronjob/backup-openstack backup-${REPLICAS}node
           oc -n $NAMESPACE wait --for=condition=complete job/backup-${REPLICAS}node
     - script: &backup_check
@@ -117,10 +118,13 @@ spec:
     try:
     - script:
         content: |
+          set -e
+          oc -n $NAMESPACE delete --ignore-not-found=true job/backup-1node
           oc -n $NAMESPACE create job --from=cronjob/backup-openstack backup-1node
           oc -n $NAMESPACE create job --from=cronjob/backup-openstack2nd backup-1node-2nd
     - script:
         content: |
+          set -e
           oc -n $NAMESPACE wait --for=condition=complete job/backup-1node job/backup-1node-2nd
           ../../common/backup-assert.sh backup-1node
           ../../common/backup-assert.sh backup-1node-2nd
@@ -130,9 +134,12 @@ spec:
     try:
     - script:
         content: |
+          set -o pipefail
           oc -n $NAMESPACE create job --from=cronjob/backup-openstack custom-timestamp --dry-run=client -o json | jq '.spec.template.spec.containers[0].env += [{ "name": "BACKUP_TIMESTAMP", value:"chainsaw_unit_test" }]' | oc -n $NAMESPACE apply -f -
     - script:
         content: |
-          oc -n $NAMESPACE wait --for=condition=complete job/backup-1node
-          ../../common/backup-assert.sh backup-1node
+          set -e
+          set -o pipefail
+          oc -n $NAMESPACE wait --for=condition=complete job/custom-timestamp
+          ../../common/backup-assert.sh custom-timestamp
           oc -n $NAMESPACE get pod -o name -l job-name=custom-timestamp | xargs oc -n $NAMESPACE logs | grep 'Starting backup .* - chainsaw_unit_test'


### PR DESCRIPTION
Some of the assertions were not returning errors because multi-line scripts were not configured to exit on error.

Harden various actions of this specific test. A more general pass will be performed for other chainsaw tests in a subsequent commit.