### PR TITLE
Add input validation for MariaDBAccount and MariaDBDatabase CR fields

### DIFF
--- a/api/bases/mariadb.openstack.org_mariadbaccounts.yaml
+++ b/api/bases/mariadb.openstack.org_mariadbaccounts.yaml
@@ -63,6 +63,8 @@ spec:
                 type: string
               userName:
                 description: UserName for new account
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
             required:
             - requireTLS

--- a/api/bases/mariadb.openstack.org_mariadbdatabases.yaml
+++ b/api/bases/mariadb.openstack.org_mariadbdatabases.yaml
@@ -51,13 +51,19 @@ spec:
               defaultCharacterSet:
                 default: utf8
                 description: Default character set for this database
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
               defaultCollation:
                 default: utf8_general_ci
                 description: Default collation for this database
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
               name:
                 description: Name of the database in MariaDB
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
               secret:
                 description: Name of secret which contains DatabasePassword (deprecated)

--- a/api/v1beta1/mariadbaccount_types.go
+++ b/api/v1beta1/mariadbaccount_types.go
@@ -36,6 +36,8 @@ const (
 type MariaDBAccountSpec struct {
 	// UserName for new account
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
 	UserName string `json:"userName"`
 
 	// Name of secret which contains DatabasePassword

--- a/api/v1beta1/mariadbdatabase_types.go
+++ b/api/v1beta1/mariadbdatabase_types.go
@@ -35,11 +35,17 @@ type MariaDBDatabaseSpec struct {
 	// Name of secret which contains DatabasePassword (deprecated)
 	Secret *string `json:"secret,omitempty"`
 	// Name of the database in MariaDB
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
 	Name string `json:"name,omitempty"`
 	// +kubebuilder:default=utf8
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
 	// Default character set for this database
 	DefaultCharacterSet string `json:"defaultCharacterSet,omitempty"`
 	// +kubebuilder:default=utf8_general_ci
+	// +kubebuilder:validation:MaxLength=64
+	// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9_]+$`
 	// Default collation for this database
 	DefaultCollation string `json:"defaultCollation,omitempty"`
 }

--- a/config/crd/bases/mariadb.openstack.org_mariadbaccounts.yaml
+++ b/config/crd/bases/mariadb.openstack.org_mariadbaccounts.yaml
@@ -63,6 +63,8 @@ spec:
                 type: string
               userName:
                 description: UserName for new account
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
             required:
             - requireTLS

--- a/config/crd/bases/mariadb.openstack.org_mariadbdatabases.yaml
+++ b/config/crd/bases/mariadb.openstack.org_mariadbdatabases.yaml
@@ -51,13 +51,19 @@ spec:
               defaultCharacterSet:
                 default: utf8
                 description: Default character set for this database
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
               defaultCollation:
                 default: utf8_general_ci
                 description: Default collation for this database
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
               name:
                 description: Name of the database in MariaDB
+                maxLength: 64
+                pattern: ^[a-zA-Z0-9_]+$
                 type: string
               secret:
                 description: Name of secret which contains DatabasePassword (deprecated)


### PR DESCRIPTION
Add kubebuilder:validation:Pattern and MaxLength constraints to MariaDBAccount.spec.userName and MariaDBDatabase.spec.name, .defaultCharacterSet, .defaultCollation fields.

These fields are rendered into SQL statements and shell commands via Go text/template without escaping. While K8s metadata validation currently prevents most injection characters (the field values flow into Job names and labels), adding explicit CRD-level validation makes the protection intentional rather than accidental.

The pattern ^[a-zA-Z0-9_]+$ matches all valid MySQL identifiers and all values currently used by consuming operators (keystone, nova, glance, cinder, nova_cell0, etc.).

Jira: [OSPRH-31719](https://redhat.atlassian.net/browse/OSPRH-31719)