### PR TITLE
Use the latest installer for golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ tidy: ## Run go mod tidy on every mod file in the repo
 GOLANGCI_LINT_VERSION ?= v2.7.2
 .PHONY: golangci-lint
 golangci-lint:
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://golangci-lint.run/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	$(LOCALBIN)/golangci-lint run --fix
 
 PROCS?=$(shell expr $(shell nproc --ignore 2) / 2)


### PR DESCRIPTION
Lately, golangci-lint started providing sbom.json files along with the tarball that we are downloading for running golangci linters, and the version of the installer that we are relying upon fails to validate the tarball hash because of that.

As explained in golangci-lint changelog [1], we should now fetch the installer from a new URL to fix the issue.

[1] https://golangci-lint.run/docs/product/changelog/#v2121