### PR TITLE
Test minor updates with different galera CR images

### DIFF
--- a/test/ansible/README.md
+++ b/test/ansible/README.md
@@ -1,11 +1,13 @@
 # mariadb-operator update playbook
 
 This ansible playbooks automates the testing of mariadb-operator updates,
-including tests which disrupt the rolling update of Galera clusters:
+including updating galera CR images during the update, and disrupting
+the rolling update of Galera clusters:
 
   - Deploy the mariadb-operator from a container image
   - Deploy a Galera cluster (3-node by default)
   - Update the mariadb-operator to a new container image
+  - If configured, update the container image used by the Galera cluster
   - If configured, trigger a disruption during the galera rolling update (default)
   - Verify that the update finished succesfully
 
@@ -56,6 +58,16 @@ ansible-playbook -v playbooks/mariadb-operator-update.yaml \
                  -e mariadb_operator_image_updated=quay.io/openstack-k8s-operators/mariadb-operator-index:18.0-fr5-latest
 ```
 
+### Full end-to-end run with custom operator images, and custom container images for galera pods
+
+```bash
+ansible-playbook -v playbooks/mariadb-operator-update.yaml \
+                 -e mariadb_operator_image_initial=quay.io/openstack-k8s-operators/mariadb-operator-index:18.0-fr4-latest \
+                 -e mariadb_operator_image_updated=quay.io/openstack-k8s-operators/mariadb-operator-index:18.0-fr5-latest \
+                 -e galera_image_initial=quay.io/podified-antelope-centos9/openstack-mariadb:current-podified \
+                 -e galera_image_updated=quay.io/podified-master-centos9/openstack-mariadb:current-podified
+```
+
 ### Clean up OCP environment after a run
 
 ```bash
@@ -67,11 +79,13 @@ ansible-playbook -v playbooks/mariadb-operator-update.yaml --tags cleanup
 Important variables from `./ansible/vars/mariadb-galera-vars.yaml`
 
 | Variable | Default | Description |
-|----------|---------|------------|-
+|----------|---------|------------|
 | `tmp_dir` | `$PWD/out` | Location of temporary files |
 | `install_yamls_dir` | `{{ playbook_dir }}/../../../install_yamls` | Location of the `install_yamls` repo |
 | `mariadb_operator_image_initial` | `quay.io/.../mariadb-operator-index:latest` | Initial operator image |
 | `mariadb_operator_image_updated` | `quay.io/.../mariadb-operator-index:latest` | Target operator image for update |
+| `galera_image_initial` | _undefined_ | container image for the initial galera CR |
+| `galera_image_updated` | _undefined_ | container image for the updated galera CR |
 | `galera_cr` | `{{ tmp_dir }}/.../mariadb_v1beta1_galera.yaml` | YAML resource to instantiate the Galera CR |
 | `replicas` | `3` | Number of Galera nodes |
 | `namespace` | `openstack` | OpenStack namespace |

--- a/test/ansible/tasks/deploy_resources.yaml
+++ b/test/ansible/tasks/deploy_resources.yaml
@@ -33,6 +33,17 @@
   tags:
     - galera
 
+- name: Configure the container image for the Galera CR to deploy
+  ansible.builtin.shell: |
+    set -e
+    cr=$(grep -v containerImage {{ galera_cr_prepared }})
+    echo -e "$cr\n  containerImage: {{ galera_image_initial }}" > {{ galera_cr_prepared }}
+  changed_when: false
+  when:
+    - galera_image_initial is defined
+  tags:
+    - galera
+
 - name: Deploy the prepared Galera CR
   community.general.make:
     chdir: "{{ install_yamls_dir }}"

--- a/test/ansible/tasks/update_operator.yaml
+++ b/test/ansible/tasks/update_operator.yaml
@@ -6,6 +6,18 @@
   tags:
     - update
 
+- name: Update the container image used by the Galera CR
+  ansible.builtin.shell: |
+    set -eo pipefail
+    cr=$(grep -v containerImage {{ galera_cr_prepared }})
+    echo -e "$cr\n  containerImage: {{ galera_image_updated }}" > {{ galera_cr_prepared }}
+    oc -n {{ cr_namespace }} apply -f {{ galera_cr_prepared }}
+  changed_when: false
+  when:
+    - galera_image_updated is defined
+  tags:
+    - update
+
 - name: Wait for the mariadb-operator to be started
   ansible.builtin.shell: >
     oc -n {{ operator_namespace }} wait --for=create --timeout={{ update_timeout }} deployment/mariadb-operator-controller-manager

--- a/test/ansible/vars/mariadb-operator-vars.yaml
+++ b/test/ansible/vars/mariadb-operator-vars.yaml
@@ -8,6 +8,12 @@ tmp_dir: "{{ lookup('env', 'PWD') }}/out"
 mariadb_operator_image_initial: "quay.io/openstack-k8s-operators/mariadb-operator-index:latest"
 mariadb_operator_image_updated: "quay.io/openstack-k8s-operators/mariadb-operator-index:latest"
 
+# galera images
+# define those variables to force a specific galera image
+# during initial deployment and update
+# galera_image_initial: "quay.io/podified-antelope-centos9/openstack-mariadb:current-podified"
+# galera_image_updated: "quay.io/podified-antelope-centos9/openstack-mariadb:current-podified"
+
 # Disruption tests during update
 disruption: true
 


### PR DESCRIPTION
Improve the ansible playbook that tests mariadb-operator rolling updates, so that container images for galera CR can be updated as well. This could be used for more complex update scenarios like e.g. major upgrade of RHOSO versions.

Jira: [OSPRH-31904](https://redhat.atlassian.net/browse/OSPRH-31904)