### PR TITLE
galerabackup: retry SST while setting up backup

### DIFF
--- a/templates/galerabackup/bin/backup_galera
+++ b/templates/galerabackup/bin/backup_galera
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -eu
+set -o pipefail
 
 # API server config
 APISERVER=https://kubernetes.default.svc
@@ -9,8 +10,14 @@ NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace)
 TOKEN=$(cat ${SERVICEACCOUNT}/token)
 CACERT=${SERVICEACCOUNT}/ca.crt
 
+# Retry configuration
+: ${SST_RETRIES=10}
+: ${SST_WAIT=10}
+: ${SST_START_TIMEOUT=20}
+
 # Backup configuration
 JOINER_LOG=/tmp/joiner.log
+GARBD_LOG=/tmp/garbd.log
 TRANSFER_DIR=/backup/transfer
 BACKUP_DIR=/backup/data
 
@@ -19,6 +26,10 @@ WSREP_SST=wsrep_sst_rsync
 
 function log() {
     echo "$(date +%F_%H_%M_%S) `basename $0` $*"
+}
+
+function warn() {
+    echo "$(date +%F_%H_%M_%S) `basename $0` warning: $*"
 }
 
 function err() {
@@ -34,13 +45,77 @@ function check_arg() {
     fi
 }
 
-function finally {
+function finally() {
     last_status=$?
+    local timefmt
     timefmt=$(date -d "@$SECONDS" -u +'%H hours %M minutes %S seconds' | sed -e 's/00 [^ ]* //g' -e 's/0\([0-9]\)/\1/g')
     log "Backup of Galera cluster ${DB} finished in ${timefmt} (ret: ${last_status})"
     # do not leave incomplete dumps behind
     rm -f ${BACKUP_DIR}/${DB}_backup*.tmp
 }
+
+function garbd_select_target_and_trigger_sst() {
+    local target
+    local service
+    local output
+    local endpoint
+    local endpointfqdn
+    local members
+    local size
+
+    log "Retrieve the active endpoint for Galera cluster ${DB}"
+    service=${DB}
+    output=$(curl -s --cacert ${CACERT} --header "Content-Type:application/json" --header "Authorization: Bearer ${TOKEN}" --request GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/services/${service})
+    endpoint=$(echo "${output}" | python3 -c 'import json,sys;s=json.load(sys.stdin);print(s["spec"]["selector"]["statefulset.kubernetes.io/pod-name"])')
+
+    if [ -z "$endpoint" ]; then
+        warn "No active endpoint detected"
+        target=""
+        return 1
+    fi
+
+    log "Retrieve available members (from the quorated partition)"
+    endpointfqdn=${service}.${NAMESPACE}.svc
+    members=$(mysql ${MYSQL_OPTS} -nN -u${dbuser} -p${dbpass} -h ${endpointfqdn} -e 'select node_name from mysql.wsrep_cluster_members;')
+    log "Members found: $(echo ${members}) (service endpoint: $endpoint)"
+
+    size=$(echo -n "${members}" | wc -w)
+    if [ $size -eq 0 ]; then
+        target=""
+    elif [ $size -eq 1 ]; then
+        target=$endpoint
+    else
+        target=$(echo "$members" | grep -v "$endpoint" | head -1)
+    fi
+
+    if [ "$target" = "" ]; then
+        warn "Could not select a target to backup Galera cluster ${DB}"
+        return 1
+    else
+        log "Selecting ${target} as node to take backup from"
+    fi
+
+    # NOTE: garbd can be used to generate a backup out of a SST, but it only
+    # runs so far to connect to a galera cluster a request a SST. It does not
+    # set the SST up nor does it tracks its progress.
+    log "Trigger a Galera backup with garbd over SST"
+    targetfqdn=${target}.${DB}-galera.${NAMESPACE}.svc
+    garbd -o "pc.weight=2${GARBD_OPTS:-}" -n backup -a gcomm://${targetfqdn}:4567 -g galera_cluster -l /dev/stdout --sst rsync:${joinerfqdn}:4444/rsync_sst  --donor ${target} | tee $GARBD_LOG
+    local res=$?
+
+    # If garbd requested a SST to a node that wasn't in the primary
+    # partition at the time of the request but it still managed to connect
+    # to the node, garbd will return success even though no SST will be
+    # triggered. Catch this special case here
+    if [ $res -eq 0 ] && grep -E 'FATAL: State transfer request failed: -77' $GARBD_LOG; then
+        warn "garbd could not trigger the SST"
+        return 1
+    fi
+
+    test $res -eq 0
+    return $?
+}
+
 
 # Environment variables
 check_arg DB "name of the Galera CR to backup"
@@ -88,30 +163,7 @@ dbpass=$MYSQL_PWD
 test -n "$MYSQL_PWD"
 dbuser=root
 
-log "Retrieve the active endpoint for Galera cluster ${DB}"
-service=${DB}
-output=$(curl -s --cacert ${CACERT} --header "Content-Type:application/json" --header "Authorization: Bearer ${TOKEN}" --request GET ${APISERVER}/api/v1/namespaces/${NAMESPACE}/services/${service})
-endpoint=$(echo "${output}" | python3 -c 'import json,sys;s=json.load(sys.stdin);print(s["spec"]["selector"]["statefulset.kubernetes.io/pod-name"])')
 
-log "Retrieve available members (from the quorated partition)"
-endpointfqdn=${service}.${NAMESPACE}.svc
-members=$(mysql ${MYSQL_OPTS} -nN -u${dbuser} -p${dbpass} -h ${endpointfqdn} -e 'select node_name from mysql.wsrep_cluster_members;')
-log "Members found: $(echo ${members}) (service endpoint: $endpoint)"
-
-size=$(echo -n "${members}" | wc -w)
-if [ $size -eq 0 ]; then
-    target=""
-elif [ $size -eq 1 ]; then
-    target=$endpoint
-else
-    target=$(echo "$members" | grep -v "$endpoint" | head -1)
-fi
-
-if [ "$target" = "" ]; then
-    err "Could not select a target to backup Galera cluster ${DB}"
-else
-    log "Selecting ${target} as node to take backup from"
-fi
 
 
 #
@@ -122,7 +174,6 @@ fi
 
 # use FQDN to validate TLS connections
 joinerfqdn=$(hostname -s).${DB}-galera.${NAMESPACE}.svc
-targetfqdn=${target}.${DB}-galera.${NAMESPACE}.svc
 
 log "Start the joiner SST script"
 touch ${JOINER_LOG}
@@ -143,17 +194,41 @@ if ! kill -s 0 $joinerpid 2>/dev/null; then
 fi
 kill $tailpid 2>/dev/null
 
-log "Capture a Galera backup with garbd over SST"
-garbd -o "pc.weight=2${GARBD_OPTS:-}" -n backup -a gcomm://${targetfqdn}:4567 -g galera_cluster -l /dev/stdout --sst rsync:${joinerfqdn}:4444/rsync_sst  --donor ${target}
+# Start a backup by requesting a SST with garbd
+# Use a retry logic until the SST request is successful or
+# too many retries have been performed
+retries=$SST_RETRIES
+garbd_select_target_and_trigger_sst
 res=$?
+while [ $res -ne 0 -a $retries -gt 0 ]; do
+    warn "Could not trigger SST, retrying"
+    sleep $SST_WAIT
+    garbd_select_target_and_trigger_sst
+    res=$?
+    retries=$((retries - 1))
+done
+
 if [ $res -ne 0 ]; then
-    err "garbd returned error ${res}, backup of Galera cluster ${DB} failed"
+    err "Could not trigger SST with garbd, backup of Galera cluster ${DB} failed"
 else
-    log "garbd finished succesfully"
+    log "garbd triggered SST succesfully"
 fi
 
+# From there, a donor should initiate transfer to our local SST joiner script
+# wait until data transfer has started (this confirms that the SST started)
+start_timeout=$SST_START_TIMEOUT
+while [ $start_timeout -gt 0 ] && tail -1 $JOINER_LOG | grep -q '^ready '; do
+    log "Wait for the donor to start transferring data"
+    sleep 1
+    start_timeout=$((start_timeout - 1))
+done
+if [ $start_timeout -eq 0 ]; then
+    err "SST transfer did not start after $SST_START_TIMEOUT seconds, aborting"
+fi
+
+# Once the SST is finished, the local joiner script automatically terminates
 while kill -s 0 $joinerpid 2>/dev/null; do
-    log "Wait for the joiner SST script to exit"
+    log "Wait until the joiner SST script to finish"
     sleep 1
 done
 


### PR DESCRIPTION
There may be race conditions where the node selected for backup changes its galera state just before garbd is called to trigger a SST, which would make the SST fail and the backup job fail as well.

Implement a retry for selecting a node and requesting a SST on it, so we get more chances to avoid transient environment issues.

The retry, wait and start timeout parameter are currently hard-coded with reasonable settings for absorbing transient issues. They may be exposed in the GaleraBackup CR in a subsequent commit.

Jira: [OSPRH-32268](https://redhat.atlassian.net/browse/OSPRH-32268)