### PR TITLE
Make galerabackup work with FIPS

### DIFF
--- a/templates/galerabackup/bin/backup_galera
+++ b/templates/galerabackup/bin/backup_galera
@@ -137,6 +137,12 @@ trap finally EXIT
 if [ "${TLS:-}" = "true" ]; then
     MYSQL_OPTS="--defaults-extra-file=/etc/mysql_backup_tls.cnf"
     WSREP_SST_CFG=/etc/mysql_backup_tls.cnf
+    if [ "$(sysctl -n crypto.fips_enabled)" == "1" ]; then
+        echo FIPS enabled
+        GARBD_CIPHER='ECDHE-RSA-AES256-GCM-SHA384'
+    else
+        GARBD_CIPHER='AES128-SHA256'
+    fi
     . /etc/garbd_backup_tls.cnf
     GARBD_OPTS=";${GARBD_TLS_OPTS}"
 else

--- a/templates/galerabackup/config/garbd_backup_tls.cnf
+++ b/templates/galerabackup/config/garbd_backup_tls.cnf
@@ -1,1 +1,2 @@
-GARBD_TLS_OPTS="socket.ssl_key=/etc/pki/tls/private/galera.key;socket.ssl_cert=/etc/pki/tls/certs/galera.crt;socket.ssl_cipher=AES128-SHA256;socket.ssl_ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+: ${GARBD_CIPHER=AES128-SHA256}
+GARBD_TLS_OPTS="socket.ssl_key=/etc/pki/tls/private/galera.key;socket.ssl_cert=/etc/pki/tls/certs/galera.crt;socket.ssl_cipher=${GARBD_CIPHER};socket.ssl_ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"


### PR DESCRIPTION
When FIPS is enabled in the environment, the cipher used by garbd to connect to galera has to match how the Galera CR was configured, i.e. not use ciphers deemed insecure for FIPS.

Jira: [OSPRH-32393](https://redhat.atlassian.net/browse/OSPRH-32393)