### PR TITLE
Fix galera bootstrap deadlock when all pods are killed simultaneously

### DIFF
--- a/api/bases/mariadb.openstack.org_galeras.yaml
+++ b/api/bases/mariadb.openstack.org_galeras.yaml
@@ -345,8 +345,12 @@ spec:
             properties:
               attributes:
                 additionalProperties:
-                  description: GaleraAttributes holds startup information for a Galera
-                    host
+                  description: |-
+                    GaleraAttributes holds startup information for a Galera host.
+                    This struct is read-only from the operator's perspective — all fields
+                    are pushed by the galera pods via the report_local_galera_state script.
+                    The operator must not write to these fields to avoid a concurrency
+                    race with the deferred status merge patch.
                   properties:
                     containerID:
                       description: Identifier of the container at the time the gcomm

--- a/api/v1beta1/galera_types.go
+++ b/api/v1beta1/galera_types.go
@@ -116,7 +116,11 @@ type GaleraOverrideSpec struct {
 	Probes probes.OverrideSpec `json:"probes,omitempty"`
 }
 
-// GaleraAttributes holds startup information for a Galera host
+// GaleraAttributes holds startup information for a Galera host.
+// This struct is read-only from the operator's perspective — all fields
+// are pushed by the galera pods via the report_local_galera_state script.
+// The operator must not write to these fields to avoid a concurrency
+// race with the deferred status merge patch.
 type GaleraAttributes struct {
 	// UUID of the partition that is seen by the galera node
 	UUID string `json:"uuid,omitempty"`

--- a/config/crd/bases/mariadb.openstack.org_galeras.yaml
+++ b/config/crd/bases/mariadb.openstack.org_galeras.yaml
@@ -345,8 +345,12 @@ spec:
             properties:
               attributes:
                 additionalProperties:
-                  description: GaleraAttributes holds startup information for a Galera
-                    host
+                  description: |-
+                    GaleraAttributes holds startup information for a Galera host.
+                    This struct is read-only from the operator's perspective — all fields
+                    are pushed by the galera pods via the report_local_galera_state script.
+                    The operator must not write to these fields to avoid a concurrency
+                    race with the deferred status merge patch.
                   properties:
                     containerID:
                       description: Identifier of the container at the time the gcomm

--- a/internal/controller/galera_controller.go
+++ b/internal/controller/galera_controller.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
@@ -91,12 +92,27 @@ var allWatchFields = []string{
 	topologyField,
 }
 
+// bootstrapPodInfo tracks which pod is currently bootstrapping a galera
+// cluster, along with the containerID at injection time so the entry
+// can be invalidated when the container restarts.
+type bootstrapPodInfo struct {
+	podName     string
+	containerID string
+}
+
 // GaleraReconciler reconciles a Galera object
 type GaleraReconciler struct {
 	client.Client
 	Kclient kubernetes.Interface
 	config  *rest.Config
 	Scheme  *runtime.Scheme
+	// bootstrapping tracks the pod currently bootstrapping each Galera
+	// cluster. Keyed by types.NamespacedName. Entries are set when
+	// gcomm:// is injected and cleared when the cluster bootstraps,
+	// the pod restarts (new CID), or the CR is deleted.
+	// Joiner injection is not tracked here — the filesystem check in
+	// isGaleraContainerStartedAndWaiting handles that.
+	bootstrapping sync.Map // types.NamespacedName -> bootstrapPodInfo
 }
 
 // GetLog returns a logger object with a prefix of "controller.name" and additional controller context fields
@@ -108,25 +124,46 @@ func GetLog(ctx context.Context, controller string) logr.Logger {
 // General Galera helper functions
 //
 
-// findBestCandidate returns the node with the lowest seqno
+// findBestCandidate selects the best node to bootstrap a galera cluster.
+// It requires all replicas to have reported their state (seqno) before
+// making a decision. Prefers a node marked SafeToBootstrap; otherwise
+// picks the node with the highest seqno.
+//
+// ContainerID freshness is NOT checked here. During bootstrap recovery
+// (Bootstrapped==false), no pod has started mysqld -- pods are blocked
+// waiting for gcomm_uri -- so the seqno on disk (and thus in the
+// pushed attributes) cannot change between container restarts. Checking
+// CIDs against the live pod list would create a race: pods restart
+// faster than the reconcile cycle, causing permanent mismatches.
 func findBestCandidate(g *mariadbv1.Galera, pods []corev1.Pod, log logr.Logger) (node string, found bool) {
 	log.Info("Known attributes for bootstrapping the cluster", "attributes", g.Status.Attributes)
-	var sortedNodes []string
+
+	// Log CID mismatches for observability (not used for decisions)
 	for _, pod := range pods {
-		if cidFound, cid := getGaleraContainerID(&pod); cidFound {
-			attr, attrFound := g.Status.Attributes[pod.Name]
-			if attrFound && attr.ContainerID == cid {
-				sortedNodes = append(sortedNodes, pod.Name)
+		if _, cid := getGaleraContainerID(&pod); cid != "" {
+			if attr, ok := g.Status.Attributes[pod.Name]; ok && attr.ContainerID != cid {
+				log.Info("ContainerID differs between attribute and running pod (informational)",
+					"pod", pod.Name,
+					"podCID", cid,
+					"attrCID", attr.ContainerID)
 			}
 		}
 	}
-	sort.Strings(sortedNodes)
+
+	// Collect all pods that have pushed attributes (regardless of CID)
+	var knownNodes []string
+	for _, pod := range pods {
+		if _, ok := g.Status.Attributes[pod.Name]; ok {
+			knownNodes = append(knownNodes, pod.Name)
+		}
+	}
+	sort.Strings(knownNodes)
+
 	bestnode := ""
 	bestseqno := -1
-	for _, node := range sortedNodes {
-		// On clean shutdown, galera sets the last
-		// stopped node as 'safe to bootstrap', so use
-		// this hint when we can
+	for _, node := range knownNodes {
+		// On clean shutdown, galera sets the last stopped node as
+		// 'safe to bootstrap', so use this hint when we can.
 		if g.Status.Attributes[node].SafeToBootstrap {
 			return node, true
 		}
@@ -137,12 +174,10 @@ func findBestCandidate(g *mariadbv1.Galera, pods []corev1.Pod, log logr.Logger) 
 			bestseqno = intseqno
 		}
 	}
-	// if we pass here, a candidate is only valid if we
-	// inspected all the expected replicas (e.g. typically 3)
-	if len(sortedNodes) != int(*g.Spec.Replicas) {
+	if len(knownNodes) != int(*g.Spec.Replicas) {
 		return "", false
 	}
-	return bestnode, true //"galera-0"
+	return bestnode, true
 }
 
 // buildGcommURI builds a gcomm URI for a galera instance
@@ -160,14 +195,62 @@ func buildGcommURI(instance *mariadbv1.Galera) string {
 	return uri
 }
 
-// isBootstrapInProgress checks whether a node is currently starting a galera cluster
-func isBootstrapInProgress(instance *mariadbv1.Galera) bool {
-	for _, attr := range instance.Status.Attributes {
-		if attr.Gcomm == "gcomm://" {
-			return true
+// isBootstrapInProgress checks whether a node is currently starting a galera cluster.
+// Returns true only if the container that initiated the bootstrap is still present.
+// If the pod restarted (new CID) or no longer exists, the entry is cleared so the
+// operator can reprobe.
+func (r *GaleraReconciler) isBootstrapInProgress(instance *mariadbv1.Galera, pods []corev1.Pod) bool {
+	key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	val, ok := r.bootstrapping.Load(key)
+	if !ok {
+		return false
+	}
+	info := val.(bootstrapPodInfo)
+	for _, pod := range pods {
+		if pod.Name == info.podName {
+			if _, cid := getGaleraContainerID(&pod); cid == info.containerID {
+				return true
+			}
+			r.clearBootstrapState(instance)
+			return false
 		}
 	}
+	r.clearBootstrapState(instance)
 	return false
+}
+
+func (r *GaleraReconciler) setBootstrapInProgress(instance *mariadbv1.Galera, podName, containerID string) {
+	key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	r.bootstrapping.Store(key, bootstrapPodInfo{podName: podName, containerID: containerID})
+}
+
+func (r *GaleraReconciler) clearBootstrapState(instance *mariadbv1.Galera) {
+	key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	r.bootstrapping.Delete(key)
+}
+
+// reconstructBootstrapState detects a bootstrap already in progress by
+// probing pods for a running mysqld process. This covers the case where
+// the operator restarted and lost its in-memory state. Only probes when
+// the sync.Map has no entry for this instance.
+func (r *GaleraReconciler) reconstructBootstrapState(ctx context.Context, instance *mariadbv1.Galera, pods []corev1.Pod, h *helper.Helper, config *rest.Config) {
+	key := types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}
+	if _, ok := r.bootstrapping.Load(key); ok {
+		return
+	}
+
+	log := GetLog(ctx, "galera")
+	for _, pod := range pods {
+		if pod.Status.Phase != corev1.PodRunning || podutils.IsPodReady(&pod) {
+			continue
+		}
+		if isGaleraContainerRunningMysqld(ctx, &pod, instance, h, config) {
+			_, cid := getGaleraContainerID(&pod)
+			log.Info("Detected bootstrap already in progress", "pod", pod.Name)
+			r.setBootstrapInProgress(instance, pod.Name, cid)
+			return
+		}
+	}
 }
 
 ///
@@ -263,13 +346,7 @@ func getPodsWaitingForGcomm(ctx context.Context, pods []corev1.Pod, instance *ma
 	for _, pod := range pods {
 		if pod.Status.Phase == corev1.PodRunning && !podutils.IsPodReady(&pod) &&
 			isGaleraContainerStartedAndWaiting(ctx, &pod, instance, h, config) {
-			if _, attrFound := instance.Status.Attributes[pod.Name]; attrFound {
-				if instance.Status.Attributes[pod.Name].Gcomm == "" {
-					ret = append(ret, pod)
-				}
-			} else {
-				ret = append(ret, pod)
-			}
+			ret = append(ret, pod)
 		}
 	}
 	return
@@ -283,6 +360,21 @@ func getGaleraContainerID(pod *corev1.Pod) (found bool, CID string) {
 		}
 	}
 	return false, ""
+}
+
+// isGaleraContainerRunningMysqld checks whether mysqld is running as a
+// child of PID 1 (the init process, e.g. dumb-init). This means the
+// detect script has consumed gcomm_uri and exec'd into mysqld. Used to
+// reconstruct bootstrap state after an operator restart.
+func isGaleraContainerRunningMysqld(ctx context.Context, pod *corev1.Pod, instance *mariadbv1.Galera, h *helper.Helper, config *rest.Config) bool {
+	running := false
+	err := mariadb.ExecInPod(ctx, h, config, instance.Namespace, pod.Name, "galera",
+		[]string{"/bin/bash", "-c", "pgrep -aP1 | grep -wo mysqld"},
+		func(stdout *bytes.Buffer, _ *bytes.Buffer) error {
+			running = strings.TrimSpace(stdout.String()) == "mysqld"
+			return nil
+		})
+	return err == nil && running
 }
 
 // isGaleraContainerStartedAndWaiting checks whether the galera container is waiting for a gcomm_uri file
@@ -303,26 +395,24 @@ func isGaleraContainerStartedAndWaiting(ctx context.Context, pod *corev1.Pod, in
 // These functions have side effect and modify the galera CR's status
 //
 
-// injectGcommURI configures a pod to start galera with a given URI
+// injectGcommURI configures a pod to start galera with a given URI.
+// The URI is written directly into the pod's filesystem, which is the
+// sole consumer — the operator does not record it in Status.Attributes
+// to avoid a concurrency race with the deferred status merge patch.
+// For bootstrap URIs (gcomm://), the caller is responsible for recording
+// the bootstrap state via setBootstrapInProgress after a successful call.
+//
+// If the exec fails (e.g. transient connection error), the error is
+// returned so the reconcile event gets reprocessed, giving us a chance
+// to re-inject the URI. If the error was due to a pod restart, the next
+// reconcile will detect the new ContainerID and wait for the pod to
+// publish fresh attributes before injecting.
 func injectGcommURI(ctx context.Context, h *helper.Helper, config *rest.Config, instance *mariadbv1.Galera, pod *corev1.Pod, uri string) error {
-	err := mariadb.ExecInPod(ctx, h, config, instance.Namespace, pod.Name, "galera",
+	return mariadb.ExecInPod(ctx, h, config, instance.Namespace, pod.Name, "galera",
 		[]string{"/bin/bash", "-c", "echo '" + uri + "' > /var/lib/mysql/gcomm_uri"},
 		func(_ *bytes.Buffer, _ *bytes.Buffer) error {
-			attr := instance.Status.Attributes[pod.Name]
-			attr.Gcomm = uri
-			instance.Status.Attributes[pod.Name] = attr
 			return nil
 		})
-	// If we could not push the file in the pod, this might be due
-	// to a transient connection error. Return an error, so that
-	// this reconcile event gets reprocessed, to give us a chance
-	// to re-inject the URI into the pod.
-	//
-	// NOTE: if the error was due to a pod being restarted, the next
-	// processing of this reconcile event will automatically clean up
-	// the outdated attributes and wait for the newly restarted pod
-	// to publish up-to-date state before injecting any URI.
-	return err
 }
 
 // retrieveSequenceNumber probes a pod's galera instance for sequence number
@@ -953,13 +1043,19 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	//   . Cluster is bootstrapped as soon as one pod is available
 	instance.Status.Bootstrapped = statefulset.Status.AvailableReplicas > 0
 
+	// Clear transient in-memory bootstrap tracker now that a pod is available
+	if instance.Status.Bootstrapped {
+		r.clearBootstrapState(instance)
+	}
+
 	if instance.Status.Bootstrapped {
 		// Sync Ready condition
 		instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 
 		// All pods that are 'Ready' have their local galera running and connected.
 		// We can clear their attributes from our status as these are now outdated.
-		for _, pod := range getReadyPods(podList.Items) {
+		readyPods := getReadyPods(podList.Items)
+		for _, pod := range readyPods {
 			name := pod.Name
 			if _, found := instance.Status.Attributes[name]; found {
 				log.Info("Galera started", "pod", name)
@@ -970,12 +1066,22 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		// The remaining pods will become joiner nodes. Wait until they have
 		// reported their status to the operator, and then configure them
 		// as joiners.
+		// Only push joiner gcomm if there are actually Ready pods to
+		// join. If AvailableReplicas is stale (which persists for a long
+		// time due to the startup probe timeout, 240s by default) and no
+		// pods are truly Ready, pushing a joiner gcomm would cause the
+		// pod to start mysqld against dead peers, wasting a restart cycle.
+		if len(readyPods) == 0 {
+			log.Info("Bootstrapped flag is set but no pods are Ready, skipping joiner push")
+		}
 		runningPods := getPodsWaitingForGcomm(ctx, podList.Items, instance, helper, r.config)
 		for _, pod := range runningPods {
+			if len(readyPods) == 0 {
+				break
+			}
 			name := pod.Name
 			joinerURI := buildGcommURI(instance)
 			log.Info("Pushing gcomm URI to joiner", "pod", name)
-			// Setting the gcomm attribute marks this pod as 'currently joining the cluster'
 			err := injectGcommURI(ctx, helper, r.config, instance, &pod, joinerURI)
 			if err != nil {
 				log.Error(err, "Failed to push gcomm URI", "pod", name)
@@ -991,7 +1097,11 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	// Note:
 	//   . a pod whose phase is Running but who is not Ready hasn't started
 	//     galera, it is waiting for the operator's instructions.
-	if !instance.Status.Bootstrapped && !isBootstrapInProgress(instance) {
+	if !instance.Status.Bootstrapped {
+		r.reconstructBootstrapState(ctx, instance, podList.Items, helper, r.config)
+	}
+
+	if !instance.Status.Bootstrapped && !r.isBootstrapInProgress(instance, podList.Items) {
 		var node string
 		found := false
 
@@ -1010,7 +1120,6 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		if found {
 			pod := getPodFromName(podList.Items, node)
 			log.Info("Pushing gcomm URI to bootstrap", "pod", node)
-			// Setting the gcomm attribute marks this pod as 'currently bootstrapping the cluster'
 			err := injectGcommURI(ctx, helper, r.config, instance, pod, "gcomm://")
 			if err != nil {
 				log.Error(err, "Failed to push gcomm URI", "pod", node)
@@ -1018,6 +1127,8 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 				// another injection (see details in injectGcommURI())
 				return ctrl.Result{}, err
 			}
+			_, cid := getGaleraContainerID(pod)
+			r.setBootstrapInProgress(instance, pod.Name, cid)
 		}
 	}
 
@@ -1031,6 +1142,14 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		if len(oldPods) > 0 {
 			log.Info("Requeuing until all replicas are available")
 			return ctrl.Result{RequeueAfter: time.Duration(3) * time.Second}, nil
+		}
+		// Requeue periodically during bootstrap recovery. After a
+		// joiner gcomm is pushed to a pod that starts and fails
+		// mysqld, the pod restart may not generate an event that
+		// triggers a new reconcile. Without requeue the operator
+		// would stop retrying.
+		if !instance.Status.Bootstrapped {
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
 	}
@@ -1274,6 +1393,8 @@ func (r *GaleraReconciler) getRootMariadbAccountName(instance *mariadbv1.Galera)
 
 func (r *GaleraReconciler) reconcileDelete(ctx context.Context, instance *mariadbv1.Galera, helper *helper.Helper) (ctrl.Result, error) {
 	helper.GetLogger().Info("Reconciling Service delete")
+
+	r.clearBootstrapState(instance)
 
 	// Remove our finalizer from the db svc
 	svc, err := service.GetServiceWithName(ctx, helper, instance.Name, instance.Namespace)

--- a/internal/controller/galera_controller_test.go
+++ b/internal/controller/galera_controller_test.go
@@ -1,0 +1,277 @@
+package controller
+
+import (
+	"testing"
+
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func int32Ptr(i int32) *int32 { return &i }
+
+func makeGalera(replicas int32, attrs map[string]mariadbv1.GaleraAttributes) *mariadbv1.Galera {
+	return makeGaleraNamed("test-ns", "galera", replicas, attrs)
+}
+
+func makeGaleraNamed(ns, name string, replicas int32, attrs map[string]mariadbv1.GaleraAttributes) *mariadbv1.Galera {
+	return &mariadbv1.Galera{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: mariadbv1.GaleraSpec{
+			GaleraSpecCore: mariadbv1.GaleraSpecCore{
+				Replicas: int32Ptr(replicas),
+			},
+		},
+		Status: mariadbv1.GaleraStatus{
+			Attributes: attrs,
+		},
+	}
+}
+
+func makePod(name, containerID string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "galera", ContainerID: containerID},
+			},
+		},
+	}
+}
+
+func TestFindBestCandidate_AllFreshCIDs(t *testing.T) {
+	g := makeGalera(3, map[string]mariadbv1.GaleraAttributes{
+		"galera-0": {Seqno: "100", ContainerID: "cid-0"},
+		"galera-1": {Seqno: "100", ContainerID: "cid-1"},
+		"galera-2": {Seqno: "101", ContainerID: "cid-2"},
+	})
+	pods := []corev1.Pod{
+		makePod("galera-0", "cid-0"),
+		makePod("galera-1", "cid-1"),
+		makePod("galera-2", "cid-2"),
+	}
+	node, found := findBestCandidate(g, pods, ctrl.Log)
+	if !found {
+		t.Fatal("expected to find a candidate")
+	}
+	if node != "galera-2" {
+		t.Errorf("expected galera-2 (highest seqno), got %s", node)
+	}
+}
+
+func TestFindBestCandidate_SafeToBootstrap(t *testing.T) {
+	g := makeGalera(3, map[string]mariadbv1.GaleraAttributes{
+		"galera-0": {Seqno: "100", ContainerID: "cid-0", SafeToBootstrap: true},
+		"galera-1": {Seqno: "200", ContainerID: "cid-1"},
+		"galera-2": {Seqno: "200", ContainerID: "cid-2"},
+	})
+	pods := []corev1.Pod{
+		makePod("galera-0", "cid-0"),
+		makePod("galera-1", "cid-1"),
+		makePod("galera-2", "cid-2"),
+	}
+	node, found := findBestCandidate(g, pods, ctrl.Log)
+	if !found {
+		t.Fatal("expected to find a candidate")
+	}
+	if node != "galera-0" {
+		t.Errorf("expected galera-0 (SafeToBootstrap), got %s", node)
+	}
+}
+
+func TestFindBestCandidate_StaleCIDs_StillWorks(t *testing.T) {
+	// Pods have restarted and have new CIDs, but attributes still have
+	// old CIDs from a previous push. findBestCandidate should NOT care
+	// about CID freshness -- it only needs seqno data from all replicas.
+	g := makeGalera(3, map[string]mariadbv1.GaleraAttributes{
+		"galera-0": {Seqno: "100", ContainerID: "old-cid-0"},
+		"galera-1": {Seqno: "100", ContainerID: "old-cid-1"},
+		"galera-2": {Seqno: "100", ContainerID: "old-cid-2"},
+	})
+	pods := []corev1.Pod{
+		makePod("galera-0", "new-cid-0"),
+		makePod("galera-1", "new-cid-1"),
+		makePod("galera-2", "new-cid-2"),
+	}
+	node, found := findBestCandidate(g, pods, ctrl.Log)
+	if !found {
+		t.Fatal("expected to find a candidate even with stale CIDs")
+	}
+	t.Logf("Selected node: %s", node)
+}
+
+func TestFindBestCandidate_NotAllReported(t *testing.T) {
+	// Only 2 of 3 replicas have pushed attributes
+	g := makeGalera(3, map[string]mariadbv1.GaleraAttributes{
+		"galera-0": {Seqno: "100", ContainerID: "cid-0"},
+		"galera-1": {Seqno: "100", ContainerID: "cid-1"},
+	})
+	pods := []corev1.Pod{
+		makePod("galera-0", "cid-0"),
+		makePod("galera-1", "cid-1"),
+		makePod("galera-2", "cid-2"),
+	}
+	_, found := findBestCandidate(g, pods, ctrl.Log)
+	if found {
+		t.Error("should not find candidate when not all replicas have reported")
+	}
+}
+
+func TestFindBestCandidate_UnequalSeqno(t *testing.T) {
+	g := makeGalera(3, map[string]mariadbv1.GaleraAttributes{
+		"galera-0": {Seqno: "100", ContainerID: "cid-0"},
+		"galera-1": {Seqno: "200", ContainerID: "cid-1"},
+		"galera-2": {Seqno: "150", ContainerID: "cid-2"},
+	})
+	pods := []corev1.Pod{
+		makePod("galera-0", "cid-0"),
+		makePod("galera-1", "cid-1"),
+		makePod("galera-2", "cid-2"),
+	}
+	node, found := findBestCandidate(g, pods, ctrl.Log)
+	if !found {
+		t.Fatal("expected to find a candidate")
+	}
+	if node != "galera-1" {
+		t.Errorf("expected galera-1 (highest seqno=200), got %s", node)
+	}
+}
+
+// Reproduces the exact scenario from the live failure
+func TestFindBestCandidate_LiveScenario_AllEqualSeqno(t *testing.T) {
+	g := makeGalera(3, map[string]mariadbv1.GaleraAttributes{
+		"openstack-cell1-galera-0": {
+			UUID:        "918a5168-7773-11f1-bce9-4ad1e2e8f877",
+			Seqno:       "1892",
+			ContainerID: "cri-o://4c72f596",
+		},
+		"openstack-cell1-galera-1": {
+			UUID:        "918a5168-7773-11f1-bce9-4ad1e2e8f877",
+			Seqno:       "1892",
+			ContainerID: "cri-o://90a8fb82",
+		},
+		"openstack-cell1-galera-2": {
+			UUID:        "918a5168-7773-11f1-bce9-4ad1e2e8f877",
+			Seqno:       "1892",
+			ContainerID: "cri-o://7cd39428",
+		},
+	})
+	// Pods have DIFFERENT CIDs (restarted since pushing)
+	pods := []corev1.Pod{
+		makePod("openstack-cell1-galera-0", "cri-o://NEW-0"),
+		makePod("openstack-cell1-galera-1", "cri-o://NEW-1"),
+		makePod("openstack-cell1-galera-2", "cri-o://NEW-2"),
+	}
+	node, found := findBestCandidate(g, pods, ctrl.Log)
+	if !found {
+		t.Fatal("expected to find a candidate despite CID mismatches")
+	}
+	t.Logf("Selected node: %s", node)
+}
+
+func TestIsBootstrapInProgress_NoState(t *testing.T) {
+	r := &GaleraReconciler{}
+	g := makeGaleraNamed("ns", "galera", 3, nil)
+	pods := []corev1.Pod{makePod("galera-0", "cid-0")}
+	if r.isBootstrapInProgress(g, pods) {
+		t.Error("expected false when no bootstrap state exists")
+	}
+}
+
+func TestIsBootstrapInProgress_SameCID(t *testing.T) {
+	r := &GaleraReconciler{}
+	g := makeGaleraNamed("ns", "galera", 3, nil)
+	r.setBootstrapInProgress(g, "galera-0", "cid-0")
+
+	pods := []corev1.Pod{makePod("galera-0", "cid-0")}
+	if !r.isBootstrapInProgress(g, pods) {
+		t.Error("expected true when bootstrap pod is still running with same CID")
+	}
+}
+
+func TestIsBootstrapInProgress_PodRestarted(t *testing.T) {
+	r := &GaleraReconciler{}
+	g := makeGaleraNamed("ns", "galera", 3, nil)
+	r.setBootstrapInProgress(g, "galera-0", "old-cid")
+
+	pods := []corev1.Pod{makePod("galera-0", "new-cid")}
+	if r.isBootstrapInProgress(g, pods) {
+		t.Error("expected false when bootstrap pod has a new CID (restarted)")
+	}
+	// State should have been cleared
+	if r.isBootstrapInProgress(g, pods) {
+		t.Error("expected state to be cleared after CID mismatch")
+	}
+}
+
+func TestIsBootstrapInProgress_PodGone(t *testing.T) {
+	r := &GaleraReconciler{}
+	g := makeGaleraNamed("ns", "galera", 3, nil)
+	r.setBootstrapInProgress(g, "galera-0", "cid-0")
+
+	// Pod list does not contain galera-0
+	pods := []corev1.Pod{makePod("galera-1", "cid-1")}
+	if r.isBootstrapInProgress(g, pods) {
+		t.Error("expected false when bootstrap pod is no longer in pod list")
+	}
+	// State should have been cleared
+	if r.isBootstrapInProgress(g, pods) {
+		t.Error("expected state to be cleared after pod disappeared")
+	}
+}
+
+func TestClearBootstrapState(t *testing.T) {
+	r := &GaleraReconciler{}
+	g := makeGaleraNamed("ns", "galera", 3, nil)
+	r.setBootstrapInProgress(g, "galera-0", "cid-0")
+
+	pods := []corev1.Pod{makePod("galera-0", "cid-0")}
+	if !r.isBootstrapInProgress(g, pods) {
+		t.Fatal("precondition: bootstrap should be in progress")
+	}
+
+	r.clearBootstrapState(g)
+	if r.isBootstrapInProgress(g, pods) {
+		t.Error("expected false after clearBootstrapState")
+	}
+}
+
+func TestBootstrapState_MultipleInstances(t *testing.T) {
+	r := &GaleraReconciler{}
+	g1 := makeGaleraNamed("ns", "cell1-galera", 3, nil)
+	g2 := makeGaleraNamed("ns", "cell2-galera", 3, nil)
+
+	r.setBootstrapInProgress(g1, "cell1-galera-0", "cid-1")
+
+	pods1 := []corev1.Pod{makePod("cell1-galera-0", "cid-1")}
+	pods2 := []corev1.Pod{makePod("cell2-galera-0", "cid-2")}
+
+	if !r.isBootstrapInProgress(g1, pods1) {
+		t.Error("expected true for cell1")
+	}
+	if r.isBootstrapInProgress(g2, pods2) {
+		t.Error("expected false for cell2 (no bootstrap set)")
+	}
+
+	// Setting bootstrap for cell2 should not affect cell1
+	r.setBootstrapInProgress(g2, "cell2-galera-0", "cid-2")
+	if !r.isBootstrapInProgress(g1, pods1) {
+		t.Error("cell1 bootstrap should still be in progress")
+	}
+	if !r.isBootstrapInProgress(g2, pods2) {
+		t.Error("cell2 bootstrap should now be in progress")
+	}
+
+	// Clearing cell1 should not affect cell2
+	r.clearBootstrapState(g1)
+	if r.isBootstrapInProgress(g1, pods1) {
+		t.Error("cell1 should be cleared")
+	}
+	if !r.isBootstrapInProgress(g2, pods2) {
+		t.Error("cell2 should still be in progress")
+	}
+}


### PR DESCRIPTION
    Three issues combined to delay galera cluster recovery by 12-54+
    minutes when all pods were killed at once.
    
    1. Status update race: injectGcommURI() stored gcomm state in
       Status.Attributes. The deferred PatchInstance (JSON merge patch)
       wrote this back, overwriting pod-pushed attributes (including
       ContainerIDs) with stale data from the start of the reconcile.
    
       Fix: stop writing gcomm state to Status.Attributes entirely.
       Bootstrap-in-progress state is tracked via a sync.Map on the
       reconciler, keyed by the Galera CR's NamespacedName, storing
       only the bootstrap pod name and its containerID at injection time.
       Joiner injection is not tracked at all — the filesystem check in
       isGaleraContainerStartedAndWaiting (test ! -f gcomm_uri && pgrep
       detect_gcomm_and_start.sh) already prevents double-injection,
       since the detect script exec's into mysqld after consuming the file.
    
    2. Unnecessary ContainerID check in findBestCandidate(): the function
       required all replicas to have attributes with ContainerIDs matching
       the currently running containers. But pods restart faster than the
       reconcile cycle, so CIDs never match. This check is unnecessary
       during bootstrap recovery because no pod has started mysqld (pods
       are blocked waiting for gcomm_uri), so the seqno on the persistent
       volume cannot change between container restarts.
    
       Fix: remove the CID comparison from findBestCandidate(). Only
       require that all replicas have pushed attributes with valid seqnos.
       Log CID mismatches for observability without blocking the decision.
    
    3. Spurious joiner push: when all pods were killed, the StatefulSet's
       AvailableReplicas could remain > 0 briefly (stale status), causing
       Bootstrapped to be true. The operator pushed joiner gcomm URIs to
       pods, making them start mysqld against dead peers and wasting a
       restart cycle.
    
       Fix: skip joiner gcomm push when Bootstrapped is set but no pods
       are actually Ready.
    
    Also add a periodic 10s requeue when not bootstrapped, ensuring the
    reconciler retries even when no external events trigger a reconcile.
    
    isBootstrapInProgress returns true only if the container that
    initiated the bootstrap is still present (matching CID). If the pod
    restarted or is gone, the entry is cleared so the operator can
    reprobe. injectGcommURI and getPodsWaitingForGcomm remain free
    functions with no shared state.

Generated-By: claude-opus-4-6

Jira: https://redhat.atlassian.net/browse/OSPRH-32408