### PR TITLE
Bail out during init if the API server is unreachable

### DIFF
--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -122,6 +122,10 @@ function kolla_set_all_configs {
         # mysql_root_auth.sh, so that we definitely use the root password defined in
         # the cluster, not whatever possibly stale PW is in local files.
         MYSQL_ROOT_AUTH_BYPASS_CHECKS=true source /var/lib/operator-scripts/mysql_root_auth.sh
+        if [ $? -ne 0 ]; then
+            echo -e "Could not retrieve root password from K8s API, aborting bootstrap"
+            exit 1
+        fi
     else
         echo -e "Could not access /var/lib/operator-scripts/mysql_root_auth.sh script; "
         echo -e "using environment DB_ROOT_PASSWORD and creating pw cache directory manually"

--- a/templates/galera/bin/mysql_root_auth.sh
+++ b/templates/galera/bin/mysql_root_auth.sh
@@ -83,8 +83,18 @@ GALERA_CR=$(curl -s \
     --header "Authorization: Bearer ${TOKEN}" \
     "${APISERVER}/${MARIADB_API}/namespaces/${NAMESPACE}/galeras/${GALERA_INSTANCE}")
 
+if ! echo "${GALERA_CR}" | python3 -c "import json, sys; json.load(sys.stdin)" 2>/dev/null; then
+    echo "ERROR: failed to retrieve Galera CR from K8s API, cannot determine root password" >&2
+    return 1
+fi
+
 # note jq is not installed in the galera image, macgyvering w/ python instead
 SECRET_NAME=$(echo "${GALERA_CR}" | python3 -c "import json, sys; print(json.load(sys.stdin)['status']['rootDatabaseSecret'])")
+
+if [ -z "${SECRET_NAME}" ]; then
+    echo "ERROR: Galera CR does not contain status.rootDatabaseSecret, cannot determine root password" >&2
+    return 1
+fi
 
 # get password from secret
 PASSWORD=$(curl -s \
@@ -94,6 +104,11 @@ PASSWORD=$(curl -s \
     "${APISERVER}/${K8S_API}/namespaces/${NAMESPACE}/secrets/${SECRET_NAME}" \
     | python3 -c "import json, sys; print(json.load(sys.stdin)['data']['DatabasePassword'])" \
     | base64 -d)
+
+if [ -z "${PASSWORD}" ]; then
+    echo "ERROR: failed to retrieve root password from secret '${SECRET_NAME}', cannot determine root password" >&2
+    return 1
+fi
 
 # Special step for the unlikely case that root PW is being changed but the
 # account.sh script failed to complete.  Test this password (which came from


### PR DESCRIPTION
The init container mysql-bootstrap checks whether the root password is still valid and changes it if it required, so that on startup, the galera pod is always able to probe the mysqld process.

This check requires the API server to be up and running. If the API server cannot be reached, no root password check can be attempted, and the init container should error out, to make the pod restart until the API is reacheable again. We do so because the real service container 'galera' requires a password file to be present to run probes, and without the API server the file can't be recreated anyway.

Jira: [OSPRH-29205](https://redhat.atlassian.net/browse/OSPRH-29205)