### PR TITLE
Fail fast when trying to connect to a cluster without active nodes

### DIFF
--- a/templates/galera/bin/detect_gcomm_and_start.sh
+++ b/templates/galera/bin/detect_gcomm_and_start.sh
@@ -53,5 +53,15 @@ else
     echo "this POD will now join cluster $URI"
 fi
 
+# OSPRH-32408: if a galera node tries to join a cluster which happens
+# to be gone, it will try to connect to any node in the gcomm:// URI
+# for at most pc.wait_prim_timeout seconds.
+# however if /var/lib/mysql/gvwstate.dat is present, the joiner will
+# try to connect indefinitely, leaving the joiner stuck if the cluster
+# isn't bootstrapped.
+# remove this file prior to start, as it is only useful to recover
+# from a previous crash when no bootstrap orchestration is available.
+rm -f /var/lib/mysql/gvwstate.dat
+
 rm -f $URI_FILE
 exec /usr/libexec/mysqld --wsrep-cluster-address="$URI"

--- a/templates/galera/config/galera.cnf.in
+++ b/templates/galera/config/galera.cnf.in
@@ -48,7 +48,7 @@ wsrep_debug = 0
 wsrep_drupal_282555_workaround = 0
 wsrep_on = ON
 wsrep_provider = /usr/lib64/galera/libgalera_smm.so
-wsrep_provider_options = pc.wait_prim=FALSE;gcache.recover=no;gmcast.listen_addr=tcp://{ PODIP }:4567
+wsrep_provider_options = pc.wait_prim_timeout=PT5S;gcache.recover=no;gmcast.listen_addr=tcp://{ PODIP }:4567
 wsrep_retry_autocommit = 1
 wsrep_slave_threads = 1
 wsrep_sst_method = rsync

--- a/templates/galera/config/galera_tls.cnf.in
+++ b/templates/galera/config/galera_tls.cnf.in
@@ -4,7 +4,7 @@ ssl-cert = /etc/pki/tls/certs/galera.crt
 ssl-key = /etc/pki/tls/private/galera.key
 ssl-ca = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 ssl-cipher = !SSLv2:kEECDH:kRSA:kEDH:kPSK:+3DES:!aNULL:!eNULL:!MD5:!EXP:!RC4:!SEED:!IDEA:!DES:!SSLv3:!TLSv1
-wsrep_provider_options = pc.wait_prim=FALSE;gcache.recover=no;gmcast.listen_addr=tcp://{ PODIP }:4567;socket.ssl_key=/etc/pki/tls/private/galera.key;socket.ssl_cert=/etc/pki/tls/certs/galera.crt;socket.ssl_cipher={ SSL_CIPHER };socket.ssl_ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem;
+wsrep_provider_options = pc.wait_prim_timeout=PT5S;gcache.recover=no;gmcast.listen_addr=tcp://{ PODIP }:4567;socket.ssl_key=/etc/pki/tls/private/galera.key;socket.ssl_cert=/etc/pki/tls/certs/galera.crt;socket.ssl_cipher={ SSL_CIPHER };socket.ssl_ca=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem;
 
 [sst]
 sockopt = cipher=!SSLv2:kEECDH:kRSA:kEDH:kPSK:+3DES:!aNULL:!eNULL:!MD5:!EXP:!RC4:!SEED:!IDEA:!DES:!SSLv3:!TLSv1


### PR DESCRIPTION
In a previous commit [1] we set up the galera config with option "pc.wait_prim=FALSE" to "fail early in case galera cannot join a primary partition". However the semantics of this flags just configures the galera library to not enforce any wait_prim_timeout, so instead it stays stuck indefinitely trying to connect to a cluster until a node becomes available in the primary partition.

Update the setting to forcibly use pc_wait_timeout with a value that is low enough to achieve the desired effect.

With the new setting, if a new tries to connect to a cluster that just becomes unavailable (e.g. due to a race), the joining node won't stay stuck for the whole startup timeout (240s) unecessarily.

This helps recovering fast for when all galera nodes crash at the same or similar time.

Jira: [OSPRH-32408](https://redhat.atlassian.net/browse/OSPRH-32408)

[1] 340ee75509903d13261d3c264b53b6ce5f58a201