### PR TITLE
disallow blank root pw from being set under any circumstances

### DIFF
--- a/templates/galera/bin/mysql_bootstrap.sh
+++ b/templates/galera/bin/mysql_bootstrap.sh
@@ -138,6 +138,11 @@ function kolla_set_all_configs {
         echo -e "Created ${PW_CACHE_DIR} pw cache directory and set ownership"
     fi
 
+    if [ -z "${DB_ROOT_PASSWORD}" ]; then
+        echo -e "DB_ROOT_PASSWORD is blank, aborting bootstrap"
+        exit 1
+    fi
+
 }
 
 if [ -e /var/lib/mysql/mysql ]; then


### PR DESCRIPTION
in 96304603f2aa4df19a5b7 we added logic to cancel mysql_bootstrap.sh if mysql_root_auth.sh returns a failure code.  harden this logic further by additionally exiting if the root password is blank for any reason; this prevents against uncaught problems in mysql_root_auth.sh, as well as if mysql_root_auth.sh were not accessible and the legacy "fallback" path for getting root password were engaged.

within account.sh, a blank DatabasePassword is already disallowed so this path should be good already.