### PR TITLE
Add PodDisruptionBudget for Galera to prevent quorum loss during rolling reboots

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,6 +124,18 @@ rules:
   - patch
   - update
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/internal/controller/galera_controller.go
+++ b/internal/controller/galera_controller.go
@@ -36,6 +36,7 @@ import (
 	env "github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	helper "github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/pdb"
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
@@ -44,11 +45,13 @@ import (
 	util "github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubectl/pkg/util/podutils"
@@ -501,6 +504,9 @@ func clearOldPodsAttributesOnScaleDown(ctx context.Context, instance *mariadbv1.
 
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete;patch
 
+// RBAC required to manage PodDisruptionBudgets for multi-replica deployments
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
+
 // RBAC required to manipulate Topology resources
 // +kubebuilder:rbac:groups=topology.openstack.org,resources=topologies,verbs=get;list;watch;update
 
@@ -588,6 +594,7 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 		condition.UnknownCondition(condition.ServiceAccountReadyCondition, condition.InitReason, condition.ServiceAccountReadyInitMessage),
 		condition.UnknownCondition(condition.RoleReadyCondition, condition.InitReason, condition.RoleReadyInitMessage),
 		condition.UnknownCondition(condition.RoleBindingReadyCondition, condition.InitReason, condition.RoleBindingReadyInitMessage),
+		condition.UnknownCondition(condition.PDBReadyCondition, condition.InitReason, condition.PDBReadyInitMessage),
 	)
 
 	instance.Status.Conditions.Init(&cl)
@@ -712,6 +719,38 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, req ctrl.Request) (res
 	}
 
 	instance.Status.Conditions.MarkTrue(condition.CreateServiceReadyCondition, condition.CreateServiceReadyMessage)
+
+	//
+	// PodDisruptionBudget
+	//
+	if instance.Spec.Replicas != nil && *instance.Spec.Replicas > 1 {
+		pdbSpec := pdb.MaxUnavailablePodDisruptionBudget(
+			instance.Name,
+			instance.Namespace,
+			intstr.FromInt(1),
+			mariadb.LabelSelectors(instance, "galera"),
+		)
+		pdbInstance := pdb.NewPDB(pdbSpec, 5*time.Second)
+
+		ctrlResult, err := pdbInstance.CreateOrPatch(ctx, helper)
+		if err != nil {
+			log.Error(err, "Could not apply PDB")
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.PDBReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.PDBReadyErrorMessage, err.Error()))
+			return ctrl.Result{}, err
+		} else if (ctrlResult != ctrl.Result{}) {
+			return ctrlResult, nil
+		}
+	} else {
+		err := pdb.DeletePDBWithName(ctx, helper, instance.Name, instance.Namespace)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to delete PDB: %w", err)
+		}
+	}
+	instance.Status.Conditions.MarkTrue(condition.PDBReadyCondition, condition.PDBReadyMessage)
 
 	// Map of all resources that may cause a rolling service restart
 	inputHashEnv := make(map[string]env.Setter)
@@ -1274,6 +1313,7 @@ func (r *GaleraReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).

--- a/test/chainsaw/common/galera-assert.yaml
+++ b/test/chainsaw/common/galera-assert.yaml
@@ -31,6 +31,10 @@ status:
     reason: Ready
     status: "True"
     type: MariaDBAccountReady
+  - message: PodDisruptionBudget completed
+    reason: Ready
+    status: "True"
+    type: PDBReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/chainsaw/common/galera-no-secret-assert.yaml
+++ b/test/chainsaw/common/galera-no-secret-assert.yaml
@@ -30,6 +30,10 @@ status:
     reason: Ready
     status: "True"
     type: MariaDBAccountReady
+  - message: PodDisruptionBudget completed
+    reason: Ready
+    status: "True"
+    type: PDBReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/chainsaw/tests/galera-name-with-galera/galera-assert.yaml
+++ b/test/chainsaw/tests/galera-name-with-galera/galera-assert.yaml
@@ -29,6 +29,10 @@ status:
     reason: Ready
     status: "True"
     type: MariaDBAccountReady
+  - message: PodDisruptionBudget completed
+    reason: Ready
+    status: "True"
+    type: PDBReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/chainsaw/tests/galera-topology/galera-topology-assert.yaml
+++ b/test/chainsaw/tests/galera-topology/galera-topology-assert.yaml
@@ -33,6 +33,10 @@ status:
     reason: Ready
     status: "True"
     type: MariaDBAccountReady
+  - message: PodDisruptionBudget completed
+    reason: Ready
+    status: "True"
+    type: PDBReady
   - message: RoleBinding created
     reason: Ready
     status: "True"

--- a/test/chainsaw/tests/missing-dbrootpassword/galera-assert.yaml
+++ b/test/chainsaw/tests/missing-dbrootpassword/galera-assert.yaml
@@ -26,6 +26,10 @@ status:
     severity: Warning
     status: "False"
     type: InputReady
+  - message: PodDisruptionBudget completed
+    reason: Ready
+    status: "True"
+    type: PDBReady
   - message: RoleBinding created
     reason: Ready
     status: "True"


### PR DESCRIPTION
During an OCP MCP rolling reboot, MCO drains nodes sequentially but does not wait for application pods to become Ready on the previous node before draining the next one. For Galera on a compact (3-node) cluster, this causes quorum loss: the pod on the just-rebooted node is still in Init while the pod on the next node is already being evicted, leaving only 1/3 members running.

Add a PodDisruptionBudget with maxUnavailable=1, matching the pattern used by infra-operator for RabbitMQ. This ensures MCO's drain is blocked until all but one Galera pod are Ready, preventing the overlapping disruption window that causes quorum loss.

The PDB is only created when replicas > 1 and is cleaned up when scaling down to a single replica.