### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/galera_webhook.go
+++ b/api/v1beta1/galera_webhook.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	common_webhook "github.com/openstack-k8s-operators/lib-common/modules/common/webhook"
@@ -39,8 +38,6 @@ type GaleraDefaults struct {
 }
 
 var galeraDefaults GaleraDefaults
-
-var _ webhook.Defaulter = &Galera{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Galera) Default() {
@@ -62,8 +59,6 @@ func (spec *GaleraSpec) Default() {
 func (spec *GaleraSpecCore) Default() {
 	// nothing here yet
 }
-
-var _ webhook.Validator = &Galera{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Galera) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)