### PR TITLE
Fix unanchored regex in report_local_galera_state.py

### DIFF
--- a/templates/galera/bin/report_local_galera_state.py
+++ b/templates/galera/bin/report_local_galera_state.py
@@ -112,7 +112,7 @@ def push_state(api, namespace, galera_name, pod_name, detected):
 
 def report_state(push: bool):
     pod_name = socket.gethostname()
-    galera_name = re.sub(r'-galera-[0-9]*', '', pod_name)
+    galera_name = re.sub(r'-galera-[0-9]+$', '', pod_name)
 
     svc_account = "/var/run/secrets/kubernetes.io/serviceaccount"
     with open(os.path.join(svc_account, "namespace")) as f:

--- a/test/chainsaw/tests/galera-name-with-galera/chainsaw-test.yaml
+++ b/test/chainsaw/tests/galera-name-with-galera/chainsaw-test.yaml
@@ -1,0 +1,25 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: galera-name-with-galera
+spec:
+  description: >
+    Verify that a Galera CR whose name contains '-galera-' can bootstrap
+    successfully. Regression test for a bug where report_local_galera_state.py
+    stripped all occurrences of '-galera-' from the pod hostname instead of
+    just the trailing StatefulSet ordinal suffix.
+  steps:
+  - name: Deploy Galera with embedded -galera- in CR name
+    description: >
+      Deploy a 1-node Galera cluster named 'test-galera-cluster' and verify
+      it reaches Ready. The pod hostname will be
+      'test-galera-cluster-galera-0', which triggers the bug if the regex
+      is unanchored.
+    bindings:
+    - name: replicas
+      value: 1
+    try:
+    - apply:
+        file: ./galera.yaml
+    - assert:
+        file: ./galera-assert.yaml

--- a/test/chainsaw/tests/galera-name-with-galera/galera-assert.yaml
+++ b/test/chainsaw/tests/galera-name-with-galera/galera-assert.yaml
@@ -1,0 +1,67 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: test-galera-cluster
+spec:
+  replicas: ($replicas)
+  secret: osp-secret
+  storageRequest: 500M
+status:
+  bootstrapped: true
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: Create service completed
+    reason: Ready
+    status: "True"
+    type: CreateServiceReady
+  - message: Deployment completed
+    reason: Ready
+    status: "True"
+    type: DeploymentReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: InputReady
+  - message: MariaDBAccount System account 'root' creation complete
+    reason: Ready
+    status: "True"
+    type: MariaDBAccountReady
+  - message: RoleBinding created
+    reason: Ready
+    status: "True"
+    type: RoleBindingReady
+  - message: Role created
+    reason: Ready
+    status: "True"
+    type: RoleReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
+  - message: Service config create completed
+    reason: Ready
+    status: "True"
+    type: ServiceConfigReady
+  - message: Input data complete
+    reason: Ready
+    status: "True"
+    type: TLSInputReady
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: test-galera-cluster-galera
+spec:
+  replicas: ($replicas)
+  selector:
+    matchLabels:
+      app: galera
+      galera/name: test-galera-cluster
+  serviceName: test-galera-cluster-galera
+status:
+  availableReplicas: ($replicas)
+  readyReplicas: ($replicas)
+  replicas: ($replicas)

--- a/test/chainsaw/tests/galera-name-with-galera/galera.yaml
+++ b/test/chainsaw/tests/galera-name-with-galera/galera.yaml
@@ -1,0 +1,9 @@
+apiVersion: mariadb.openstack.org/v1beta1
+kind: Galera
+metadata:
+  name: test-galera-cluster
+spec:
+  replicas: ($replicas)
+  secret: osp-secret
+  storageClass: local-storage
+  storageRequest: 500M


### PR DESCRIPTION
The regex that derives the Galera CR name from the pod hostname was unanchored, causing re.sub to strip every '-galera-<digits>' occurrence rather than just the trailing StatefulSet ordinal suffix.

Note this fix, while small, adds a chainsaw test to assert the fix.  A better option might be a Python test suite, however I don't know how to introduce a new test suite here that would integrate with CI appropriately.

Closes: https://github.com/openstack-k8s-operators/mariadb-operator/issues/515
References: [OSPRH-33045](https://redhat.atlassian.net/browse/OSPRH-33045)